### PR TITLE
Update stone count labels in VGame

### DIFF
--- a/src/components/reversi/VGame.vue
+++ b/src/components/reversi/VGame.vue
@@ -8,10 +8,10 @@
       <h1>{{ current }}</h1>
     </v-layout>
     <v-layout justify-center>
-      <h1>白の手番：{{ board.whites }}</h1>
+      <h1>白の石数：{{ board.whites }}</h1>
     </v-layout>
     <v-layout justify-center>
-      <h1>黒の手番：{{ board.blacks }}</h1>
+      <h1>黒の石数：{{ board.blacks }}</h1>
     </v-layout>
   </v-container>
 </template>


### PR DESCRIPTION
## Summary
- display 白の石数/黒の石数 instead of turn labels for stone counts

## Testing
- `npm run test:unit` *(fails: Could not locate module @/components/HelloWorld.vue)*
- `npm run lint -- --no-fix` *(fails: warning Replace `row` with `(row)` at src/models/reversi.ts)*
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_689714e62f088325acb53a21a1fda0af)