### PR TITLE
shouldPass() のテストを追加

### DIFF
--- a/tests/unit/reversi.spec.ts
+++ b/tests/unit/reversi.spec.ts
@@ -2,6 +2,48 @@ import { describe, it, expect } from "vitest";
 import { Board, CellState, Point } from "@/models/reversi";
 
 describe("Board", () => {
+  describe("shouldPass()", () => {
+    it("初期状態では黒はパスしない（有効な手が存在する）", () => {
+      const board = new Board();
+      expect(board.shouldPass()).toBe(false);
+    });
+
+    it("初期状態では白もパスしない（turn を切り替えて確認）", () => {
+      const board = new Board();
+      board.next();
+      expect(board.shouldPass()).toBe(false);
+    });
+
+    it("全マスが黒石で埋まっているとき白手番ではパスになる", () => {
+      const board = new Board();
+      board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      board.turn = CellState.White;
+      expect(board.shouldPass()).toBe(true);
+    });
+
+    it("全マスが白石で埋まっているとき黒手番ではパスになる", () => {
+      const board = new Board();
+      board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.White)),
+      );
+      board.turn = CellState.Black;
+      expect(board.shouldPass()).toBe(true);
+    });
+
+    it("空きマスがあっても挟める相手石がなければパスになる", () => {
+      const board = new Board();
+      // 盤面を全部黒で埋めて1マスだけ空ける（黒手番では隣が全部黒なので挟めない）
+      board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      board.rows[0].cells[0].state = CellState.None;
+      board.turn = CellState.Black;
+      expect(board.shouldPass()).toBe(true);
+    });
+  });
+
   it("初期状態で黒が2個ある", () => {
     const board = new Board();
     expect(board.blacks).toBe(2);


### PR DESCRIPTION
closes #31

## 概要

`shouldPass()` メソッドのユニットテストを追加。

## テストケース（5件）

1. 初期状態では黒はパスしない
2. 初期状態では白もパスしない
3. 全マスが黒石で埋まっているとき白手番ではパスになる
4. 全マスが白石で埋まっているとき黒手番ではパスになる
5. 空きマスがあっても挟める相手石がなければパスになる

## なぜ今テストを書くか

Tier 2 でゲームオーバー検出（#25）を実装するとき、`shouldPass()` を拡張することになる。
変更前にテストを整備しておくことで、既存のオートパス動作を壊していないことを CI で自動確認できる。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)