### PR TITLE
オートパス発生時にスナックバーで通知する

### DIFF
--- a/src/components/reversi/VGame.vue
+++ b/src/components/reversi/VGame.vue
@@ -12,12 +12,34 @@
     <div class="d-flex justify-center">
       <h1>黒の石：{{ store.board.blacks }}</h1>
     </div>
+    <v-snackbar
+      v-model="showPassNotice"
+      :timeout="3000"
+      color="info"
+      location="top"
+    >
+      {{ passMessage }}
+    </v-snackbar>
   </v-container>
 </template>
 
 <script setup lang="ts">
+import { computed, watch, ref } from "vue";
 import VBoard from "@/components/reversi/VBoard.vue";
 import { useGameStore } from "@/stores/game";
+import { CellState } from "@/models/reversi";
 
 const store = useGameStore();
+const showPassNotice = ref(false);
+
+const passMessage = computed(() =>
+  store.lastPassed === CellState.Black ? "黒はパスです" : "白はパスです",
+);
+
+watch(
+  () => store.lastPassed,
+  (val) => {
+    if (val !== null) showPassNotice.value = true;
+  },
+);
 </script>

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,17 +1,31 @@
-import { reactive, computed } from "vue";
+import { reactive, computed, ref } from "vue";
 import { defineStore } from "pinia";
 import { Board, CellState, Point } from "@/models/reversi";
 
 export const useGameStore = defineStore("game", () => {
   const board = reactive(new Board());
+  const lastPassed = ref<CellState | null>(null);
 
   const current = computed(() =>
     board.turn === CellState.Black ? "黒の手番" : "白の手番",
   );
 
   function put(x: number, y: number) {
-    board.put(new Point(x, y));
+    const p = new Point(x, y);
+    const turnBefore = board.turn;
+    const wasEmpty = board.ref(p).isNone;
+
+    board.put(p);
+
+    const stonePlaced = wasEmpty && !board.ref(p).isNone;
+    // 石が置かれたのにターンが戻ってきた = 相手がパスされた
+    if (stonePlaced && board.turn === turnBefore) {
+      lastPassed.value =
+        turnBefore === CellState.Black ? CellState.White : CellState.Black;
+    } else {
+      lastPassed.value = null;
+    }
   }
 
-  return { board, current, put };
+  return { board, current, put, lastPassed };
 });

--- a/tests/unit/gameStore.spec.ts
+++ b/tests/unit/gameStore.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useGameStore } from "@/stores/game";
+import { CellState } from "@/models/reversi";
 
 describe("useGameStore", () => {
   beforeEach(() => {
@@ -21,5 +22,34 @@ describe("useGameStore", () => {
     const store = useGameStore();
     store.put(3, 2);
     expect(store.current).toBe("白の手番");
+  });
+
+  describe("lastPassed", () => {
+    it("初期状態では null", () => {
+      const store = useGameStore();
+      expect(store.lastPassed).toBeNull();
+    });
+
+    it("パスが発生しない通常の手では null のまま", () => {
+      const store = useGameStore();
+      store.put(3, 2);
+      expect(store.lastPassed).toBeNull();
+    });
+
+    it("オートパスが発生したとき、パスされた側の色が入る", () => {
+      const store = useGameStore();
+      // 黒が (0,0) に置いたら白がパスになる盤面を作る
+      // 全マス黒で埋めて (0,0) だけ空け、(1,0) を白にする
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      store.board.rows[0].cells[0].state = CellState.None;
+      store.board.rows[0].cells[1].state = CellState.White;
+      store.board.turn = CellState.Black;
+
+      store.put(0, 0); // 黒が (0,0) に置く → (1,0) が反転 → 白は置く場所がなくパス
+
+      expect(store.lastPassed).toBe(CellState.White);
+    });
   });
 });


### PR DESCRIPTION
closes #28

## 概要

オートパスが発生しても UI に何も表示されず、ユーザーが気づけなかった問題を修正。

## 変更内容

- `src/stores/game.ts`: `lastPassed` を追加。`put()` 前後のターンを比較してオートパスを検出
- `src/components/reversi/VGame.vue`: `v-snackbar` でパス通知を表示（3秒後に自動消去）
- `tests/unit/gameStore.spec.ts`: `lastPassed` のテスト3件追加

## デバッグメモ

旧 Vue CLI が生成した `src/**/*.js` がローカルに残っており、Vitest が `game.ts` より `game.js` を優先して読み込んでいた。
`.js` ファイルを削除することで解決（`.gitignore` 済みだが手動削除が必要だった）。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)