### PR TITLE
両者パスでゲームオーバーを検出して勝者を表示する

### DIFF
--- a/src/components/reversi/VGame.vue
+++ b/src/components/reversi/VGame.vue
@@ -12,6 +12,19 @@
     <div class="d-flex justify-center">
       <h1>黒の石：{{ store.board.blacks }}</h1>
     </div>
+    <v-dialog v-model="store.isGameOver" persistent max-width="400">
+      <v-card>
+        <v-card-title class="text-h5 text-center pt-6">ゲーム終了</v-card-title>
+        <v-card-text class="text-center text-h6">
+          <span v-if="store.winner === CellState.Black">黒の勝ち 🎉</span>
+          <span v-else-if="store.winner === CellState.White">白の勝ち 🎉</span>
+          <span v-else>引き分け</span>
+          <div class="mt-2 text-body-1">
+            黒 {{ store.board.blacks }} 対 白 {{ store.board.whites }}
+          </div>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
     <v-snackbar
       v-model="showPassNotice"
       :timeout="3000"

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -10,6 +10,21 @@ export const useGameStore = defineStore("game", () => {
     board.turn === CellState.Black ? "黒の手番" : "白の手番",
   );
 
+  // 両者ともパスになる = どちらの手番でも置ける場所がない
+  const isGameOver = computed(() => {
+    const currentTurnCanPass = board.shouldPass();
+    board.next();
+    const otherTurnCanPass = board.shouldPass();
+    board.next();
+    return currentTurnCanPass && otherTurnCanPass;
+  });
+
+  const winner = computed((): CellState | null => {
+    if (board.blacks > board.whites) return CellState.Black;
+    if (board.whites > board.blacks) return CellState.White;
+    return null;
+  });
+
   function put(x: number, y: number) {
     const p = new Point(x, y);
     const turnBefore = board.turn;
@@ -27,5 +42,5 @@ export const useGameStore = defineStore("game", () => {
     }
   }
 
-  return { board, current, put, lastPassed };
+  return { board, current, put, lastPassed, isGameOver, winner };
 });

--- a/tests/unit/gameStore.spec.ts
+++ b/tests/unit/gameStore.spec.ts
@@ -24,6 +24,50 @@ describe("useGameStore", () => {
     expect(store.current).toBe("白の手番");
   });
 
+  describe("isGameOver / winner", () => {
+    it("初期状態ではゲームオーバーでない", () => {
+      const store = useGameStore();
+      expect(store.isGameOver).toBe(false);
+    });
+
+    it("両者ともパスになるとゲームオーバーになる", () => {
+      const store = useGameStore();
+      // 全マスを黒で埋める（どちらも置けない）
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      expect(store.isGameOver).toBe(true);
+    });
+
+    it("黒が多いとき黒の勝ち", () => {
+      const store = useGameStore();
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      expect(store.winner).toBe(CellState.Black);
+    });
+
+    it("白が多いとき白の勝ち", () => {
+      const store = useGameStore();
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.White)),
+      );
+      expect(store.winner).toBe(CellState.White);
+    });
+
+    it("同数のとき引き分け（null）", () => {
+      const store = useGameStore();
+      // 32マスを黒、32マスを白で埋める
+      let count = 0;
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => {
+          cell.state = count++ < 32 ? CellState.Black : CellState.White;
+        }),
+      );
+      expect(store.winner).toBeNull();
+    });
+  });
+
   describe("lastPassed", () => {
     it("初期状態では null", () => {
       const store = useGameStore();


### PR DESCRIPTION
closes #25

## 概要

石を全部置いてもゲームが終わらず勝敗が分からない問題を修正。

## 変更内容

- `src/stores/game.ts`: `isGameOver`（両者ともパス判定）と `winner`（石数比較）を追加
- `src/components/reversi/VGame.vue`: ゲームオーバー時に `v-dialog` で勝者を表示
- `tests/unit/gameStore.spec.ts`: `isGameOver` / `winner` のテスト5件追加

## テスト方針（TDD）

Red → Green → Refactor の順で実装。
`shouldPass()` テスト（#31）が安全網として機能した。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)