### PR TITLE
リセットボタンを追加してゲームをやり直せるようにする

### DIFF
--- a/src/components/reversi/VGame.vue
+++ b/src/components/reversi/VGame.vue
@@ -23,6 +23,11 @@
             黒 {{ store.board.blacks }} 対 白 {{ store.board.whites }}
           </div>
         </v-card-text>
+        <v-card-actions class="justify-center pb-4">
+          <v-btn color="primary" variant="elevated" @click="store.reset()">
+            もう一度
+          </v-btn>
+        </v-card-actions>
       </v-card>
     </v-dialog>
     <v-snackbar

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,4 +1,4 @@
-import { reactive, computed, ref } from "vue";
+import { reactive, computed, ref, toRaw } from "vue";
 import { defineStore } from "pinia";
 import { Board, CellState, Point } from "@/models/reversi";
 
@@ -11,12 +11,15 @@ export const useGameStore = defineStore("game", () => {
   );
 
   // 両者ともパスになる = どちらの手番でも置ける場所がない
+  // toRaw で next() を呼ぶことで reactive なターン変更を起こさずに相手番を検査する
   const isGameOver = computed(() => {
     const currentTurnCanPass = board.shouldPass();
-    board.next();
+    if (!currentTurnCanPass) return false;
+    const raw = toRaw(board);
+    raw.next();
     const otherTurnCanPass = board.shouldPass();
-    board.next();
-    return currentTurnCanPass && otherTurnCanPass;
+    raw.next();
+    return otherTurnCanPass;
   });
 
   const winner = computed((): CellState | null => {

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -25,6 +25,17 @@ export const useGameStore = defineStore("game", () => {
     return null;
   });
 
+  function reset() {
+    const fresh = new Board();
+    board.turn = fresh.turn;
+    board.rows.forEach((row, i) => {
+      row.cells.forEach((cell, j) => {
+        cell.state = fresh.rows[i].cells[j].state;
+      });
+    });
+    lastPassed.value = null;
+  }
+
   function put(x: number, y: number) {
     const p = new Point(x, y);
     const turnBefore = board.turn;
@@ -42,5 +53,5 @@ export const useGameStore = defineStore("game", () => {
     }
   }
 
-  return { board, current, put, lastPassed, isGameOver, winner };
+  return { board, current, put, reset, lastPassed, isGameOver, winner };
 });

--- a/tests/unit/gameStore.spec.ts
+++ b/tests/unit/gameStore.spec.ts
@@ -68,6 +68,45 @@ describe("useGameStore", () => {
     });
   });
 
+  describe("reset", () => {
+    it("reset を呼ぶと石が初期配置に戻る", () => {
+      const store = useGameStore();
+      store.put(3, 2);
+      store.reset();
+      expect(store.board.blacks).toBe(2);
+      expect(store.board.whites).toBe(2);
+    });
+
+    it("reset を呼ぶと黒の手番に戻る", () => {
+      const store = useGameStore();
+      store.put(3, 2);
+      store.reset();
+      expect(store.current).toBe("黒の手番");
+    });
+
+    it("reset を呼ぶと lastPassed が null になる", () => {
+      const store = useGameStore();
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      store.board.rows[0].cells[0].state = CellState.None;
+      store.board.rows[0].cells[1].state = CellState.White;
+      store.board.turn = CellState.Black;
+      store.put(0, 0);
+      store.reset();
+      expect(store.lastPassed).toBeNull();
+    });
+
+    it("reset を呼ぶとゲームオーバーが解除される", () => {
+      const store = useGameStore();
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      store.reset();
+      expect(store.isGameOver).toBe(false);
+    });
+  });
+
   describe("lastPassed", () => {
     it("初期状態では null", () => {
       const store = useGameStore();


### PR DESCRIPTION
## Summary

- `store.reset()` を追加し、盤面・手番・lastPassed を初期状態に戻す
- ゲームオーバーダイアログに「もう一度」ボタンを追加
- `reset` の単体テスト4件追加（石数・手番・lastPassed・isGameOver の初期化を確認）

closes #26

## Test plan

- [ ] `npm run test:coverage` 全テスト通過を確認
- [ ] ゲームを最後まで進めてゲームオーバーダイアログが出ることを確認
- [ ] 「もう一度」ボタンで盤面が初期状態に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)