### PR TITLE
build スクリプトの vue-tsc に --noEmit を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc && vite build",
+    "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
     "type-check": "vue-tsc --noEmit",
     "test:unit": "vitest",


### PR DESCRIPTION
## Summary

- `npm run build` で `vue-tsc` に `--noEmit` がなかったため、ビルドのたびに `src/` 配下に `.js` ファイルが生成されていた
- この `.js` が Vitest・dev サーバーで `.ts` より優先されるため、`.ts` への変更が反映されないバグが発生していた（石が置けない・修正が効かないなど）
- `vue-tsc --noEmit && vite build` に変更。型チェックのみ行い、コンパイル出力は vite に任せる

closes #161

## Root cause timeline

1. `npm run build` → `vue-tsc`（noEmit なし）→ `src/stores/game.js` 等を生成
2. Vitest が `.ts` より `.js` を優先ロード
3. `game.ts` に加えた修正が `game.js` によって無効化される

## Test plan

- [ ] `npm run build` 後に `find src -name "*.js"` で何も出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)