### PR TITLE
predev・prebuild で src の stale な .js を自動削除する

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "clean": "find src -name '*.js' -delete",
+    "predev": "npm run clean",
     "dev": "vite",
+    "prebuild": "npm run clean",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview",
     "type-check": "vue-tsc --noEmit",


### PR DESCRIPTION
## Summary

- `npm run clean`（`find src -name '*.js' -delete`）スクリプトを追加
- `predev` / `prebuild` フックで `clean` を自動実行
- これにより `npm run dev` / `npm run build` のたびに stale な `.js` が消える

## 背景

#161 で `vue-tsc --noEmit` を追加したが、それ以前に `npm run build` を実行した
開発者のローカルには `src/**/*.js` が残ったまま。`.gitignore` 管理外のため
pull しても消えず、stale な `.js` が `.ts` より優先されて読み込まれる問題が継続する。

この PR により、`npm run dev` を実行するだけで自動クリーンアップされる。

closes #163

## Test plan

- [ ] `npm run build` 後に `find src -name '*.js'` で何も出ないことを確認
- [ ] `npm run dev` の起動ログで clean が先に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)