### PR TITLE
置ける場所を半透明の白丸でハイライト表示する

### DIFF
--- a/src/components/reversi/VCell.vue
+++ b/src/components/reversi/VCell.vue
@@ -2,6 +2,7 @@
   <div class="cell-wrapper" @click="onClick">
     <div class="cell"></div>
     <div class="stone" :class="stoneClass"></div>
+    <div v-if="isValid" class="valid-hint"></div>
   </div>
 </template>
 
@@ -17,6 +18,10 @@ const stoneClass = computed(() => ({
   "white-stone": props.cell.isWhite,
   "black-stone": props.cell.isBlack,
 }));
+
+const isValid = computed(() =>
+  store.validMoves.some((p) => p.x === props.cell.x && p.y === props.cell.y),
+);
 
 function onClick() {
   store.put(props.cell.x, props.cell.y);
@@ -50,5 +55,17 @@ function onClick() {
 
 .black-stone {
   background-color: black;
+}
+
+.valid-hint {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  height: 11px;
+  width: 11px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.4);
+  pointer-events: none;
 }
 </style>

--- a/src/models/reversi.ts
+++ b/src/models/reversi.ts
@@ -106,6 +106,18 @@ export class Board {
     return count;
   }
 
+  public validMoves(): Point[] {
+    const moves: Point[] = [];
+    for (let y = 0; y < 8; y++) {
+      for (let x = 0; x < 8; x++) {
+        if (this.search(new Point(x, y)).length > 0) {
+          moves.push(new Point(x, y));
+        }
+      }
+    }
+    return moves;
+  }
+
   // パスのロジック：全マスを検索、ひっくり返せるマスがなければ飛ばす
   public shouldPass(): boolean {
     for (let i = 0; i < 8; i++) {

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -22,6 +22,8 @@ export const useGameStore = defineStore("game", () => {
     return otherTurnCanPass;
   });
 
+  const validMoves = computed(() => board.validMoves());
+
   const winner = computed((): CellState | null => {
     if (board.blacks > board.whites) return CellState.Black;
     if (board.whites > board.blacks) return CellState.White;
@@ -56,5 +58,14 @@ export const useGameStore = defineStore("game", () => {
     }
   }
 
-  return { board, current, put, reset, lastPassed, isGameOver, winner };
+  return {
+    board,
+    current,
+    put,
+    reset,
+    lastPassed,
+    isGameOver,
+    winner,
+    validMoves,
+  };
 });

--- a/tests/unit/reversi.spec.ts
+++ b/tests/unit/reversi.spec.ts
@@ -44,6 +44,27 @@ describe("Board", () => {
     });
   });
 
+  describe("validMoves()", () => {
+    it("初期状態で黒の有効手は4マスある", () => {
+      const board = new Board();
+      expect(board.validMoves()).toHaveLength(4);
+    });
+
+    it("初期状態の黒の有効手に (3,2) が含まれる", () => {
+      const board = new Board();
+      const moves = board.validMoves();
+      expect(moves.some((p) => p.x === 3 && p.y === 2)).toBe(true);
+    });
+
+    it("全マスが埋まっているとき有効手は0個", () => {
+      const board = new Board();
+      board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      expect(board.validMoves()).toHaveLength(0);
+    });
+  });
+
   it("初期状態で黒が2個ある", () => {
     const board = new Board();
     expect(board.blacks).toBe(2);


### PR DESCRIPTION
## Summary

- `Board.validMoves()` を追加して現在の手番の有効手座標一覧を返す
- `useGameStore` に `validMoves` computed を追加
- `VCell` でその座標と一致するセルに半透明の白丸（`.valid-hint`）を表示

closes #27

## Test plan

- [ ] `npm run dev` でボードを開き、黒の有効手4マスに白丸が表示される
- [ ] 石を置いたあと白の有効手に白丸が移動する
- [ ] 石が置いてあるマスには白丸が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)