### PR TITLE
GitHub Pages への自動デプロイを追加する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run build
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
+import { createRouter, createWebHashHistory, RouteRecordRaw } from "vue-router";
 import VMain from "@/components/VMain.vue";
 import VGame from "@/components/reversi/VGame.vue";
 
@@ -8,6 +8,6 @@ const routes: Array<RouteRecordRaw> = [
 ];
 
 export default createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes,
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import vuetify from "vite-plugin-vuetify";
 import path from "path";
 
 export default defineConfig({
+  base: process.env.GITHUB_ACTIONS ? "/reversi-vue-ts/" : "/",
   plugins: [vue(), vuetify({ autoImport: true })],
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },


### PR DESCRIPTION
## Summary

- `deploy.yml` を追加（main push / 手動実行でビルド＆デプロイ）
- `vite.config.ts` に `GITHUB_ACTIONS` 環境変数で base パスを切り替える設定を追加
- GitHub Pages を Actions ソースで有効化済み

公開 URL: https://beginerbeginer.github.io/reversi-vue-ts/

closes #75

## Test plan

- [x] CI の `deploy` ジョブが通ることを確認
- [ ] https://beginerbeginer.github.io/reversi-vue-ts/ でゲームが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)