### PR TITLE
feat(e2e): Playwright E2E テストセットアップ (#80)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,34 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
+        "@playwright/test": "^1.60.0",
         "@typescript-eslint/eslint-plugin": "^8.59.4",
         "@typescript-eslint/parser": "^8.59.4",
         "@vitejs/plugin-vue": "^6.0.7",
@@ -1532,6 +1533,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6085,6 +6102,53 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type-check": "vue-tsc --noEmit",
     "test:unit": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "lint": "eslint . --ext .vue,.ts",
     "prepare": "npx simple-git-hooks || true"
   },
@@ -33,6 +34,7 @@
     "vuetify": "^4.0.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
     "@typescript-eslint/parser": "^8.59.4",
     "@vitejs/plugin-vue": "^6.0.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+});

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("リバーシ ゲーム画面", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/game");
+  });
+
+  test("初期盤面が表示される", async ({ page }) => {
+    // 8x8 = 64 セルが存在する
+    const cells = page.locator(".cell-wrapper");
+    await expect(cells).toHaveCount(64);
+  });
+
+  test("初期配置：白2・黒2の石が置かれている", async ({ page }) => {
+    await expect(page.locator(".white-stone")).toHaveCount(2);
+    await expect(page.locator(".black-stone")).toHaveCount(2);
+  });
+
+  test("初期手番は黒", async ({ page }) => {
+    await expect(page.getByText("黒の手番")).toBeVisible();
+  });
+
+  test("石を置くと手番が変わる", async ({ page }) => {
+    // 黒が置ける合法手のひとつ（初期盤面では (2,3) など）をクリック
+    // 盤面は0-indexed で x=col, y=row
+    // VRow は board.rows を v-for しており、VCell は row.cells を v-for している
+    // cell-wrapper を行・列の順で取得
+    const cells = page.locator(".cell-wrapper");
+    // 初期盤面で黒の合法手: (2,3), (3,2), (4,5), (5,4) = 0-indexed
+    // セルのインデックス = y*8 + x
+    // (2,3) → 3*8+2 = 26
+    await cells.nth(26).click();
+    await expect(page.getByText("白の手番")).toBeVisible();
+  });
+
+  test("石の合計数が正しく表示される", async ({ page }) => {
+    await expect(page.getByText(/白の石：\d+/)).toBeVisible();
+    await expect(page.getByText(/黒の石：\d+/)).toBeVisible();
+  });
+});

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 test.describe("リバーシ ゲーム画面", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/game");
+    await page.goto("/#/game");
   });
 
   test("初期盤面が表示される", async ({ page }) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,11 @@ import vue from "@vitejs/plugin-vue";
 import vuetify from "vite-plugin-vuetify";
 import path from "path";
 
-export default defineConfig({
-  base: process.env.GITHUB_ACTIONS ? "/reversi-vue-ts/" : "/",
+export default defineConfig(({ command }) => ({
+  base:
+    command === "build" && process.env.GITHUB_ACTIONS
+      ? "/reversi-vue-ts/"
+      : "/",
   plugins: [vue(), vuetify({ autoImport: true })],
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },
@@ -17,10 +20,11 @@ export default defineConfig({
         inline: ["vuetify"],
       },
     },
+    include: ["tests/unit/**/*.spec.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "json-summary"],
       include: ["src/**/*.ts", "src/**/*.vue"],
     },
   },
-});
+}));


### PR DESCRIPTION
## 何をしたか

- `@playwright/test` を devDependencies に追加
- `playwright.config.ts` を作成（Vite dev server 自動起動、Chromium ブラウザ使用）
- `tests/e2e/game.spec.ts` を作成（5 つの基本ゲームテスト）
- `.github/workflows/e2e.yml` を作成（CI での E2E テスト実行）
- `package.json` に `test:e2e` スクリプトを追加
- `main` ブランチとのマージコンフリクトを解消（`package-lock.json` の `devDependencies` に `@commitlint` パッケージと `@playwright/test` を両立）

## なぜしたか

リバーシゲームの主要な UI 動作（初期盤面表示・石カウント・手番切替）を自動検証する E2E テスト基盤を整備するため。また、`main` ブランチで追加された変更（GitHub Pages デプロイ、ハイライト表示など）との競合を解消し、PR をマージ可能な状態にするため。

## テスト確認

- [ ] `npm run test:unit` が通ることを確認した
- [ ] `npm run type-check` が通ることを確認した
- [ ] `npm run lint` が通ることを確認した
- [ ] 変更に対応するテストを追加した（または追加不要な理由を記載）

**E2E テスト内容**

| テスト | 内容 |
|--------|------|
| 初期盤面が表示される | `.cell-wrapper` が 64 個存在する |
| 初期配置：白2・黒2 | `.white-stone` 2個、`.black-stone` 2個 |
| 初期手番は黒 | "黒の手番" テキストが表示される |
| 石を置くと手番が変わる | セル(2,3)クリック後に "白の手番" が表示される |
| 石の合計数が表示される | "白の石：N" / "黒の石：N" テキストが表示される |

## 関連 issue