### PR TITLE
test(e2e): Playwright E2E テストセットアップと 7 件のテストケースを追加する

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,34 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,5 +30,7 @@ jobs:
         if: failure()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: |
+            playwright-report/
+            test-results/
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules
 /dist
 /coverage
+/playwright-report
+/test-results
 
 # vitest coverage が生成する中間ファイル
 *.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
+        "@playwright/test": "^1.60.0",
         "@typescript-eslint/eslint-plugin": "^8.59.4",
         "@typescript-eslint/parser": "^8.59.4",
         "@vitejs/plugin-vue": "^6.0.7",
@@ -1532,6 +1533,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6085,6 +6102,53 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type-check": "vue-tsc --noEmit",
     "test:unit": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "lint": "eslint . --ext .vue,.ts",
     "prepare": "npx simple-git-hooks || true"
   },
@@ -33,6 +34,7 @@
     "vuetify": "^4.0.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
     "@typescript-eslint/parser": "^8.59.4",
     "@vitejs/plugin-vue": "^6.0.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+});

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -37,4 +37,89 @@ test.describe("リバーシ ゲーム画面", () => {
     await expect(page.getByText(/白の石：\d+/)).toBeVisible();
     await expect(page.getByText(/黒の石：\d+/)).toBeVisible();
   });
+
+  test("置けないセルをクリックしても盤面が変わらない", async ({ page }) => {
+    const cells = page.locator(".cell-wrapper");
+    // 左上隅 (0,0) は初期盤面では置けない
+    await cells.nth(0).click();
+    await expect(page.locator(".white-stone")).toHaveCount(2);
+    await expect(page.locator(".black-stone")).toHaveCount(2);
+  });
+
+  test("石を置くと挟まれた石が反転しスコアが更新される", async ({ page }) => {
+    const cells = page.locator(".cell-wrapper");
+    // (2,3) → index 26: 黒を置くと (3,3) の白が黒に反転 → 黒4, 白1
+    await cells.nth(26).click();
+    await expect(page.getByText("黒の石：4")).toBeVisible();
+    await expect(page.getByText("白の石：1")).toBeVisible();
+  });
+
+  test("ゲーム終了ダイアログに勝者とスコアが表示される", async ({ page }) => {
+    const cells = page.locator(".cell-wrapper");
+    // 白の最短全滅（10手）: 黒の勝ち
+    for (const index of [37, 45, 44, 29, 20, 11, 19, 43, 26, 25]) {
+      await cells.nth(index).click();
+    }
+    await expect(page.getByText("ゲーム終了")).toBeVisible();
+    await expect(page.getByText(/白の勝ち/)).toBeVisible();
+    await expect(page.getByText(/黒 \d+ 対 白 \d+/)).toBeVisible();
+  });
+
+  test("「もう一度」ボタンでゲームが初期状態に戻り再プレイできる", async ({
+    page,
+  }) => {
+    const cells = page.locator(".cell-wrapper");
+    // ゲーム終了状態を作る（白の最短全滅）
+    for (const index of [37, 45, 44, 29, 20, 11, 19, 43, 26, 25]) {
+      await cells.nth(index).click();
+    }
+    await page.getByRole("button", { name: "もう一度" }).click();
+
+    await expect(page.locator(".white-stone")).toHaveCount(2);
+    await expect(page.locator(".black-stone")).toHaveCount(2);
+    await expect(page.getByText("黒の手番")).toBeVisible();
+
+    // 再プレイできる
+    await cells.nth(26).click();
+    await expect(page.getByText("白の手番")).toBeVisible();
+  });
+
+  test("引き分け時に「引き分け」が表示される", async ({ page }) => {
+    // 黒 32・白 32 の全埋め状態を作る（両者パス → ゲーム終了）
+    await page.evaluate(() => {
+      const store = (
+        document.querySelector("#app") as any
+      ).__vue_app__.config.globalProperties.$pinia._s.get("game");
+      let i = 0;
+      store.board.rows.forEach((row: any) => {
+        row.cells.forEach((cell: any) => {
+          cell.state = i++ < 32 ? "black" : "white";
+        });
+      });
+    });
+    await expect(page.getByText("引き分け")).toBeVisible();
+  });
+
+  test("パス時にスナックバーが表示され手番が変わる", async ({ page }) => {
+    // 黒がパスになる局面: 行7以外を黒で埋め、行7は [W,_,B,B,B,W,B,B]
+    // この状態で白が (1,7) に置くと黒が挟まれずパスになる
+    await page.evaluate(() => {
+      const store = (
+        document.querySelector("#app") as any
+      ).__vue_app__.config.globalProperties.$pinia._s.get("game");
+      store.board.rows.forEach((row: any) => {
+        row.cells.forEach((cell: any) => {
+          cell.state = "black";
+        });
+      });
+      store.board.rows[7].cells[0].state = "white";
+      store.board.rows[7].cells[1].state = "none";
+      store.board.rows[7].cells[5].state = "white";
+      store.board.turn = "white";
+    });
+
+    // 白が (1,7) = index 57 に置く → (2,7)(3,7)(4,7) の黒が白に反転 → 黒は置けずパス
+    await page.locator(".cell-wrapper").nth(57).click();
+    await expect(page.getByText("黒はパスです")).toBeVisible();
+  });
 });

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("リバーシ ゲーム画面", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/game");
+  });
+
+  test("初期盤面が表示される", async ({ page }) => {
+    // 8x8 = 64 セルが存在する
+    const cells = page.locator(".cell-wrapper");
+    await expect(cells).toHaveCount(64);
+  });
+
+  test("初期配置：白2・黒2の石が置かれている", async ({ page }) => {
+    await expect(page.locator(".white-stone")).toHaveCount(2);
+    await expect(page.locator(".black-stone")).toHaveCount(2);
+  });
+
+  test("初期手番は黒", async ({ page }) => {
+    await expect(page.getByText("黒の手番")).toBeVisible();
+  });
+
+  test("石を置くと手番が変わる", async ({ page }) => {
+    // 黒が置ける合法手のひとつ（初期盤面では (2,3) など）をクリック
+    // 盤面は0-indexed で x=col, y=row
+    // VRow は board.rows を v-for しており、VCell は row.cells を v-for している
+    // cell-wrapper を行・列の順で取得
+    const cells = page.locator(".cell-wrapper");
+    // 初期盤面で黒の合法手: (2,3), (3,2), (4,5), (5,4) = 0-indexed
+    // セルのインデックス = y*8 + x
+    // (2,3) → 3*8+2 = 26
+    await cells.nth(26).click();
+    await expect(page.getByText("白の手番")).toBeVisible();
+  });
+
+  test("石の合計数が正しく表示される", async ({ page }) => {
+    await expect(page.getByText(/白の石：\d+/)).toBeVisible();
+    await expect(page.getByText(/黒の石：\d+/)).toBeVisible();
+  });
+});

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 test.describe("リバーシ ゲーム画面", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/game");
+    await page.goto("/#/game");
   });
 
   test("初期盤面が表示される", async ({ page }) => {

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("ナビゲーション", () => {
+  test("トップページからゲーム画面へ遷移できる", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "ゲームスタート！！" }).click();
+    await expect(page.locator(".cell-wrapper")).toHaveCount(64);
+  });
+
+  test("/#/game に直接アクセスするとゲーム画面が表示される", async ({
+    page,
+  }) => {
+    await page.goto("/#/game");
+    await expect(page.locator(".cell-wrapper")).toHaveCount(64);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,11 @@ import vue from "@vitejs/plugin-vue";
 import vuetify from "vite-plugin-vuetify";
 import path from "path";
 
-export default defineConfig({
-  base: process.env.GITHUB_ACTIONS ? "/reversi-vue-ts/" : "/",
+export default defineConfig(({ command }) => ({
+  base:
+    command === "build" && process.env.GITHUB_ACTIONS
+      ? "/reversi-vue-ts/"
+      : "/",
   plugins: [vue(), vuetify({ autoImport: true })],
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },
@@ -17,10 +20,11 @@ export default defineConfig({
         inline: ["vuetify"],
       },
     },
+    include: ["tests/unit/**/*.spec.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "json-summary"],
       include: ["src/**/*.ts", "src/**/*.vue"],
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary

- Playwright v1.60 のセットアップ（`playwright.config.ts`・CI ワークフロー）
- 基本 5 件のゲームテスト（初期盤面・初期配置・初期手番・手番変更・スコア表示）
- 追加 7 件のテストケース（反転・スコア更新・ゲーム終了・リセット・引き分け・パス・ナビゲーション）
- `playwright-report/` と `test-results/` を `.gitignore` に追加
- CI 失敗時に両ディレクトリを artifact としてアップロードする設定を追加

## closes

closes #170
closes #171

refs #80