### PR TITLE
test(integration): ストアと VGame.vue の結合テストを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,20 @@ jobs:
               testBuild: '${{ needs.test-build.result }}',
             };
 
-            let testDetail = '';
+            let unitDetail = '';
             try {
               const raw = JSON.parse(fs.readFileSync('test-results.json', 'utf8'));
               const { numPassedTests, numFailedTests, numTotalTests } = raw;
-              testDetail = `${numPassedTests}/${numTotalTests} passed`;
-              if (numFailedTests > 0) testDetail += `, **${numFailedTests} failed**`;
+              unitDetail = `${numPassedTests}/${numTotalTests} passed`;
+              if (numFailedTests > 0) unitDetail += `, **${numFailedTests} failed**`;
+            } catch (_) {}
+
+            let integrationDetail = '';
+            try {
+              const raw = JSON.parse(fs.readFileSync('integration-test-results.json', 'utf8'));
+              const { numPassedTests, numFailedTests, numTotalTests } = raw;
+              integrationDetail = `${numPassedTests}/${numTotalTests} passed`;
+              if (numFailedTests > 0) integrationDetail += `, **${numFailedTests} failed**`;
             } catch (_) {}
 
             let coverageDetail = '';
@@ -66,7 +74,8 @@ jobs:
               '| グループ | 結果 | 内容 |',
               '|---------|:----:|------|',
               `| Lint Check | ${icon(results.lintCheck)} | audit / type-check / lint |`,
-              `| Test & Build | ${icon(results.testBuild)} | ${testDetail} / build |`,
+              `| Unit Tests | ${icon(results.testBuild)} | ${unitDetail || 'N/A'} |`,
+              `| Integration Tests | ${icon(results.testBuild)} | ${integrationDetail || 'N/A'} |`,
               `| Coverage | — | ${coverageDetail || 'N/A'} |`,
             ].join('\n');
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,11 +14,13 @@ jobs:
       - run: npm ci --ignore-scripts
       # テスト結果（JSON）とカバレッジ（json-summary）を一度に出力
       - run: npm run test:coverage -- --reporter=json --outputFile=test-results.json
+      - run: npm run test:integration -- --run --reporter=json --outputFile=integration-test-results.json
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-artifacts
           path: |
             test-results.json
+            integration-test-results.json
             coverage/coverage-summary.json
       - run: npm run build

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "type-check": "vue-tsc --noEmit",
     "test:unit": "vitest",
+    "test:integration": "vitest --config vitest.integration.config.ts",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "lint": "eslint . --ext .vue,.ts",

--- a/tests/integration/VGame.spec.ts
+++ b/tests/integration/VGame.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import { createVuetify } from "vuetify";
+import { nextTick } from "vue";
+import VGame from "@/components/reversi/VGame.vue";
+import { useGameStore } from "@/stores/game";
+import { CellState } from "@/models/reversi";
+
+const vuetify = createVuetify();
+
+function fillBoard(
+  store: ReturnType<typeof useGameStore>,
+  state: CellState,
+): void {
+  store.board.rows.forEach((row) =>
+    row.cells.forEach((cell) => (cell.state = state)),
+  );
+}
+
+describe("VGame", () => {
+  let wrapper: ReturnType<typeof mount>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    wrapper = mount(VGame, {
+      global: { plugins: [vuetify] },
+      attachTo: document.body,
+    });
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  describe("手番・スコア表示", () => {
+    it("初期状態で「黒の手番」が表示される", () => {
+      expect(wrapper.text()).toContain("黒の手番");
+    });
+
+    it("石を置いた後「白の手番」に切り替わる", async () => {
+      const store = useGameStore();
+      store.put(3, 2);
+      await nextTick();
+      expect(wrapper.text()).toContain("白の手番");
+    });
+
+    it("初期状態で白2個・黒2個のスコアが表示される", () => {
+      expect(wrapper.text()).toContain("白の石：2");
+      expect(wrapper.text()).toContain("黒の石：2");
+    });
+
+    it("石を置いた後スコアが更新される", async () => {
+      const store = useGameStore();
+      // (3,2) に黒を置く → (3,3) の白が黒に反転 → 黒4・白1
+      store.put(3, 2);
+      await nextTick();
+      expect(wrapper.text()).toContain("黒の石：4");
+      expect(wrapper.text()).toContain("白の石：1");
+    });
+  });
+
+  describe("ゲーム終了ダイアログ", () => {
+    it("ゲームオーバー時に「ゲーム終了」ダイアログが表示される", async () => {
+      const store = useGameStore();
+      fillBoard(store, CellState.Black);
+      await nextTick();
+      expect(document.body.textContent).toContain("ゲーム終了");
+    });
+
+    it("黒が多いとき「黒の勝ち」が表示される", async () => {
+      const store = useGameStore();
+      fillBoard(store, CellState.Black);
+      await nextTick();
+      expect(document.body.textContent).toContain("黒の勝ち");
+    });
+
+    it("白が多いとき「白の勝ち」が表示される", async () => {
+      const store = useGameStore();
+      fillBoard(store, CellState.White);
+      await nextTick();
+      expect(document.body.textContent).toContain("白の勝ち");
+    });
+
+    it("黒32・白32のとき「引き分け」が表示される", async () => {
+      const store = useGameStore();
+      let count = 0;
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => {
+          cell.state = count++ < 32 ? CellState.Black : CellState.White;
+        }),
+      );
+      await nextTick();
+      expect(document.body.textContent).toContain("引き分け");
+    });
+
+    it("「もう一度」ボタンで手番・スコアが初期状態に戻る", async () => {
+      const store = useGameStore();
+      fillBoard(store, CellState.Black);
+      await nextTick();
+
+      const btn = document.body.querySelector<HTMLButtonElement>(
+        ".v-overlay-container button",
+      );
+      btn?.click();
+      await nextTick();
+
+      expect(wrapper.text()).toContain("黒の手番");
+      expect(wrapper.text()).toContain("白の石：2");
+      expect(wrapper.text()).toContain("黒の石：2");
+    });
+  });
+
+  describe("パス通知スナックバー", () => {
+    it("パスが発生したとき「白はパスです」スナックバーが表示される", async () => {
+      const store = useGameStore();
+      // 全マス黒で埋め (0,0) のみ空き・(1,0) を白にして黒番にする
+      // → 黒が (0,0) に置くと (1,0) が反転し白は置けずパスになる
+      fillBoard(store, CellState.Black);
+      store.board.rows[0].cells[0].state = CellState.None;
+      store.board.rows[0].cells[1].state = CellState.White;
+      store.board.turn = CellState.Black;
+
+      store.put(0, 0);
+      await flushPromises();
+
+      expect(document.body.textContent).toContain("白はパスです");
+    });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,15 @@
+// jsdom は window.visualViewport を実装していないため Vuetify の VOverlay が失敗する
+Object.defineProperty(window, "visualViewport", {
+  value: {
+    width: 1024,
+    height: 768,
+    offsetTop: 0,
+    offsetLeft: 0,
+    pageTop: 0,
+    pageLeft: 0,
+    scale: 1,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  },
+  writable: true,
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+import vue from "@vitejs/plugin-vue";
+import vuetify from "vite-plugin-vuetify";
+import path from "path";
+
+export default defineConfig({
+  plugins: [vue(), vuetify({ autoImport: true })],
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "./src") },
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./tests/setup.ts"],
+    server: {
+      deps: {
+        inline: ["vuetify"],
+      },
+    },
+    include: ["tests/integration/**/*.spec.ts"],
+  },
+});


### PR DESCRIPTION
closes #175

## 概要

単体テストと E2E テストの間にある「隙間」を埋めるため、結合テストを導入した。

---

## 思考プロセス

### 1. 分析：テストの「隙間」の特定

| ファイル | 何を確認しているか |
|---|---|
| `reversi.spec.ts` | Board クラスの純粋なロジック |
| `gameStore.spec.ts` | Pinia ストアの計算（isGameOver / winner / reset 等） |
| `VCell.spec.ts` | セルクリック → store.put() が呼ばれること |
| `VBoard.spec.ts` | 8行描画されること |
| `VRow.spec.ts` | 8列描画されること |
| E2E | ブラウザ越しの全体動作 |

担保されていなかった隙間：

```
store の状態変化 → VGame.vue の DOM への反映
  - store.current         → 手番テキスト更新
  - store.board.whites/blacks → スコアテキスト更新
  - store.isGameOver      → v-dialog の表示
  - store.winner          → 勝者テキストの切り替え
  - store.lastPassed      → v-snackbar の表示
  - store.reset() 呼び出し → ダイアログが閉じてUIが初期化
```

E2E が落ちたときに「ロジック層か・ストア層か・UI層か」を絞り込む手段がなかった。

### 2. 設計：何を結合テストで担保するか（t_wada 原則）

- テストには **What**（何を保証するか）を書く
- クラス名やメソッド名ではなく「ユーザーが観測できる状態」で検証する
- 例: `store.isGameOver === true → "ゲーム終了" という文字列が DOM に現れる`

### 3. 技術的判断：Vuetify テレポートへの対処

`v-dialog` / `v-snackbar` は `document.body` にテレポートするため `wrapper.find()` で到達不可。

- `attachTo: document.body` + `document.body.textContent` で確認するアプローチを採用
- `afterEach` で `wrapper.unmount()` してテレポート DOM をクリーンアップ

### 4. jsdom の `window.visualViewport` 未実装問題

Vuetify の `VOverlay`（v-dialog / v-snackbar が内部で使用）が `window.visualViewport` を参照するが jsdom に実装されていない。`tests/setup.ts` でモックを提供し `vitest.integration.config.ts` の `setupFiles` に登録して回避した。

### 5. ディレクトリ・コマンド分離

結合テストは単体テストとは性質が異なるため `tests/integration/` に分離し、専用の `test:integration` コマンドと `vitest.integration.config.ts` を用意した。

---

## 変更内容

- `tests/integration/VGame.spec.ts` — 結合テスト 10 件（手番・スコア・ゲーム終了ダイアログ・パス通知）
- `tests/setup.ts` — jsdom 用 `window.visualViewport` モック
- `vitest.integration.config.ts` — 結合テスト専用 vitest 設定
- `package.json` — `test:integration` コマンド追加
- `.github/workflows/test-build.yml` — 結合テストを CI に組み込む
- `.github/workflows/ci.yml` — PR レポートに単体・結合それぞれの件数を別行で表示

## テスト結果

- `npm run test:unit` → 34/34 passed
- `npm run test:integration` → 10/10 passed
- `npm run test:e2e` → 13/13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)