### PR TITLE
chore(release): release-please で git tag を自動化する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node


### PR DESCRIPTION
closes #177

## 概要

main にマージしてもバージョンの区切りがなかった問題を解消する。
release-please（Google 製）を導入して git tag と GitHub Release を自動化する。

## 運用フロー

```
feat / fix の PR をマージする
  ↓
GitHub Actions が Release PR を自動生成・更新
（CHANGELOG.md と package.json の version が含まれる）
  ↓
リリースしたいタイミングで Release PR をマージ
  ↓
git tag（例: v0.2.0）と GitHub Release が自動作成される
```

## バージョン番号の決まり方（SemVer）

| コミットタイプ | バージョン変化 |
|---|---|
| `fix:` | PATCH +1（v0.1.0 → v0.1.1） |
| `feat:` | MINOR +1（v0.1.0 → v0.2.0） |
| `feat!:` / `BREAKING CHANGE` | MAJOR +1（v0.1.0 → v1.0.0） |
| `chore:` / `docs:` / `test:` | 変化なし |

## なぜ semantic-release でなく release-please か

- release-please は Release PR を経由するため「いつリリースするか」を人間がコントロールできる
- 複数の feat / fix をまとめてリリースしたいケースに対応できる
- semantic-release は main マージと同時にタグが作られるため制御しにくい

🤖 Generated with [Claude Code](https://claude.com/claude-code)