### PR TITLE
chore(claude): ガードレール設定を整備する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run *)",
+      "Bash(npx vitest *)",
+      "Bash(npx playwright *)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git fetch*)",
+      "Bash(git pull)",
+      "Bash(gh pr list*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr checks*)",
+      "Bash(gh issue list*)",
+      "Bash(gh issue view*)",
+      "Bash(gh release list*)"
+    ],
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git push *--force*)",
+      "Bash(git push origin main*)",
+      "Bash(git reset --hard*)",
+      "Bash(git checkout .*)",
+      "Bash(git clean*)",
+      "Bash(git branch -D*)",
+      "Bash(rm -rf*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
+# Claude Code のローカル設定（個人の環境専用・絶対パスを含む）
+.claude/settings.local.json
+
 # Editor directories and files
 .idea
 .vscode


### PR DESCRIPTION
closes #180

## 変更内容

### `.gitignore`
- `.claude/settings.local.json` を追加（絶対パスを含む個人設定はリポジトリに含めない）

### `.claude/settings.json`（新規・リポジトリに含める）
読み取り系・テスト実行を自動許可。破壊的操作を `deny` で明示的にブロック。

**allow**（安全な操作）
- `npm run *`, `npx vitest *`, `npx playwright *`
- `git status`, `git diff*`, `git log*`, `git fetch*`, `git pull`
- `gh pr list/view/checks`, `gh issue list/view`, `gh release list`

**deny**（破壊的操作・確認必須）
- `git push --force*` / `git push origin main*`
- `git reset --hard*`, `git checkout .*`, `git clean*`
- `git branch -D*`, `rm -rf*`

### `.claude/settings.local.json`（リポジトリに含めない）
書き込み系を個人で許可。GitHub の破壊的操作を deny。

🤖 Generated with [Claude Code](https://claude.com/claude-code)