### PR TITLE
chore(claude): git pull を allow から除外する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,6 @@
       "Bash(git diff*)",
       "Bash(git log*)",
       "Bash(git fetch*)",
-      "Bash(git pull)",
       "Bash(gh pr list*)",
       "Bash(gh pr view*)",
       "Bash(gh pr checks*)",


### PR DESCRIPTION
refs #180

## 背景

PR #181 への Codex レビューで `git pull` が読み取り専用ではないと指摘された。

`git pull` = `git fetch` + `git merge` のため、ブランチが遅れている場合は
ワーキングツリーの書き換えやマージコミットの作成が発生する。

`settings.json` は「読み取り・テスト実行のみ自動許可」という設計方針なので
`git pull` を除外した。`git fetch*` は引き続き許可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)