### PR TITLE
chore(ci): paths フィルターを追加して不要なテスト実行を省く

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,34 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vite.config.ts"
+      - "vitest.integration.config.ts"
+      - "tsconfig*.json"
+      - ".eslintrc*"
+      - ".prettierrc*"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/lint-check.yml"
+      - ".github/workflows/test-build.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vite.config.ts"
+      - "vitest.integration.config.ts"
+      - "tsconfig*.json"
+      - ".eslintrc*"
+      - ".prettierrc*"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/lint-check.yml"
+      - ".github/workflows/test-build.yml"
 
 jobs:
   # audit / type-check / lint を直列で実行（軽量グループ、〜20秒）


### PR DESCRIPTION
closes #182

## 背景

.gitignore や .claude/ など設定ファイルだけを変更した PR でもテスト・ビルドの
CI が全件実行されていた。ビジネスロジックに手を加えていないのに CI が動くのは
無駄であり、レビューの待ち時間も増える。

## 変更内容

`ci.yml` の `push` / `pull_request` トリガーに `paths` フィルターを追加した。

**CI をトリガーするファイル**
- `src/**`, `tests/**`
- `package.json`, `package-lock.json`
- `vite.config.ts`, `vitest.integration.config.ts`
- `tsconfig*.json`, `.eslintrc*`, `.prettierrc*`
- `ci.yml`, `lint-check.yml`, `test-build.yml` 自身

**CI をスキップするファイル（例）**
- `*.md`（CHANGELOG.md など）
- `.gitignore`, `.claude/**`
- `release.yml`, `e2e.yml`, `deploy.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)