### PR TITLE
feat: ダークモード切り替え機能を実装する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,12 @@
   <v-app>
     <v-app-bar color="primary">
       <v-toolbar-title>Reversi</v-toolbar-title>
+      <v-spacer />
+      <v-btn icon @click="toggleTheme">
+        <v-icon>{{
+          isDark ? "mdi-weather-sunny" : "mdi-weather-night"
+        }}</v-icon>
+      </v-btn>
     </v-app-bar>
     <v-main>
       <router-view />
@@ -9,4 +15,16 @@
   </v-app>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { computed } from "vue";
+import { useTheme } from "vuetify";
+
+const theme = useTheme();
+const isDark = computed(() => theme.global.name.value === "dark");
+
+function toggleTheme() {
+  const next = isDark.value ? "light" : "dark";
+  theme.change(next);
+  localStorage.setItem("theme", next);
+}
+</script>

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -2,4 +2,11 @@ import { createVuetify } from "vuetify";
 import "@mdi/font/css/materialdesignicons.css";
 import "vuetify/styles";
 
-export default createVuetify({ icons: { defaultSet: "mdi" } });
+const saved = localStorage.getItem("theme");
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+const defaultTheme = saved ?? (prefersDark ? "dark" : "light");
+
+export default createVuetify({
+  icons: { defaultSet: "mdi" },
+  theme: { defaultTheme },
+});

--- a/tests/integration/App.spec.ts
+++ b/tests/integration/App.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createVuetify } from "vuetify";
+import { nextTick } from "vue";
+import App from "@/App.vue";
+
+const vuetify = createVuetify();
+
+describe("App", () => {
+  let wrapper: ReturnType<typeof mount>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    wrapper = mount(App, {
+      global: {
+        plugins: [vuetify],
+        stubs: { RouterView: true },
+      },
+      attachTo: document.body,
+    });
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("テーマトグルボタンが表示される", () => {
+    expect(wrapper.find("button").exists()).toBe(true);
+  });
+
+  it("ライトモード時にボタンをクリックするとダークモードに切り替わる", async () => {
+    vuetify.theme.change("light");
+    const changeSpy = vi.spyOn(vuetify.theme, "change");
+    await wrapper.find("button").trigger("click");
+    expect(changeSpy).toHaveBeenCalledWith("dark");
+  });
+
+  it("ダークモード時にボタンをクリックするとライトモードに切り替わる", async () => {
+    vuetify.theme.change("dark");
+    const changeSpy = vi.spyOn(vuetify.theme, "change");
+    await wrapper.find("button").trigger("click");
+    expect(changeSpy).toHaveBeenCalledWith("light");
+  });
+
+  it("テーマ切り替え時に localStorage に保存される", async () => {
+    vuetify.theme.change("light");
+    await wrapper.find("button").trigger("click");
+    expect(localStorage.getItem("theme")).toBe("dark");
+  });
+
+  it("ライトモード時は「夜」アイコンが表示される", async () => {
+    vuetify.theme.change("light");
+    await nextTick();
+    expect(document.body.querySelector(".mdi-weather-night")).toBeTruthy();
+  });
+
+  it("ダークモード時は「太陽」アイコンが表示される", async () => {
+    vuetify.theme.change("dark");
+    await nextTick();
+    expect(document.body.querySelector(".mdi-weather-sunny")).toBeTruthy();
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,10 @@
+// jsdom は ResizeObserver を実装していないため Vuetify の VApp レイアウトが失敗する
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 // jsdom は window.visualViewport を実装していないため Vuetify の VOverlay が失敗する
 Object.defineProperty(window, "visualViewport", {
   value: {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,9 +1,10 @@
-// jsdom は ResizeObserver を実装していないため Vuetify の VApp レイアウトが失敗する
-global.ResizeObserver = class {
+// jsdom には ResizeObserver が実装されていない。
+// Vuetify の VApp レイアウト初期化で参照されるため、テスト環境では最小実装で補う。
+globalThis.ResizeObserver = class {
   observe() {}
   unobserve() {}
   disconnect() {}
-};
+} as typeof ResizeObserver;
 
 // jsdom は window.visualViewport を実装していないため Vuetify の VOverlay が失敗する
 Object.defineProperty(window, "visualViewport", {


### PR DESCRIPTION
Vuetify のテーマ機能を利用してライト / ダークモードを切り替えられるようにした。

ユーザーが選択したテーマは localStorage に保存し、
再アクセス時に復元する。

また、Vitest によるテーマ切り替えのテストを追加した。

Vuetify の deprecated warning に対応するため、
theme.global.name.value の直接代入ではなく
theme.change() を利用する実装へ修正した。

closes #167

## 何をしたか

<!-- 変更内容を簡潔に説明する -->

## なぜしたか

<!-- 背景・目的を書く -->

## テスト確認

- [ ] `npm run test:unit` が通ることを確認した
- [ ] `npm run type-check` が通ることを確認した
- [ ] `npm run lint` が通ることを確認した
- [ ] 変更に対応するテストを追加した（または追加不要な理由を記載）

## 関連 issue

closes #
