### PR TITLE
fix: localStorage のテーマ値を検証してから Vuetify に渡す

### DIFF
--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -2,9 +2,22 @@ import { createVuetify } from "vuetify";
 import "@mdi/font/css/materialdesignicons.css";
 import "vuetify/styles";
 
+type Theme = "light" | "dark";
+const VALID_THEMES: readonly Theme[] = ["light", "dark"];
+
+export function resolveTheme(
+  saved: string | null,
+  prefersDark: boolean,
+): Theme {
+  if (saved !== null && (VALID_THEMES as readonly string[]).includes(saved)) {
+    return saved as Theme;
+  }
+  return prefersDark ? "dark" : "light";
+}
+
 const saved = localStorage.getItem("theme");
 const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-const defaultTheme = saved ?? (prefersDark ? "dark" : "light");
+const defaultTheme = resolveTheme(saved, prefersDark);
 
 export default createVuetify({
   icons: { defaultSet: "mdi" },

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,14 @@
+// jsdom は window.matchMedia を実装していないため、テスト環境では最小実装で補う。
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }),
+});
+
 // jsdom には ResizeObserver が実装されていない。
 // Vuetify の VApp レイアウト初期化で参照されるため、テスト環境では最小実装で補う。
 globalThis.ResizeObserver = class {

--- a/tests/unit/resolveTheme.spec.ts
+++ b/tests/unit/resolveTheme.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { resolveTheme } from "@/plugins/vuetify";
+
+describe("resolveTheme", () => {
+  it("'light' を返す（保存値が light の場合）", () => {
+    expect(resolveTheme("light", false)).toBe("light");
+  });
+
+  it("'dark' を返す（保存値が dark の場合）", () => {
+    expect(resolveTheme("dark", false)).toBe("dark");
+  });
+
+  it("'dark' を返す（保存値がなくシステムがダーク設定の場合）", () => {
+    expect(resolveTheme(null, true)).toBe("dark");
+  });
+
+  it("'light' を返す（保存値がなくシステムがライト設定の場合）", () => {
+    expect(resolveTheme(null, false)).toBe("light");
+  });
+
+  it("'light' を返す（保存値が無効な値の場合）", () => {
+    expect(resolveTheme("auto", false)).toBe("light");
+  });
+
+  it("'dark' を返す（保存値が無効な値でシステムがダーク設定の場合）", () => {
+    expect(resolveTheme("bogus", true)).toBe("dark");
+  });
+
+  it("'light' を返す（保存値が空文字の場合）", () => {
+    expect(resolveTheme("", false)).toBe("light");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(({ command }) => ({
   test: {
     globals: true,
     environment: "jsdom",
+    setupFiles: ["./tests/setup.ts"],
     server: {
       deps: {
         inline: ["vuetify"],


### PR DESCRIPTION
## 概要

PR #189 Codex レビュー P2 指摘の対応。

`localStorage.theme` に `"auto"` や `"bogus"` などの不正値が保存されていた場合、
Vuetify が `current: undefined` を返してアプリが起動時にクラッシュする問題を修正。

## 変更内容

- `src/plugins/vuetify.ts`: `resolveTheme(saved, prefersDark)` 関数を追加・export。
  `"light"` / `"dark"` 以外の値はシステム設定にフォールバック。
- `tests/unit/resolveTheme.spec.ts`: 7ケースのユニットテストを追加。
- `tests/setup.ts`: `window.matchMedia` のポリフィルを追加。
- `vite.config.ts`: unit テストに `setupFiles` を指定（setup.ts が読み込まれていなかった）。

closes #191