### PR TITLE
chore: release-please PR を自動マージする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
+          enable-auto-merge: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       # enable-auto-merge は v4 非対応のため、outputs.pr を使って gh コマンドで設定する。
       - name: Enable auto-merge for release PR
         if: ${{ steps.release.outputs.pr }}
-        run: gh pr merge --auto --merge "${{ steps.release.outputs.pr }}"
+        # outputs.pr は JSON オブジェクト文字列のため fromJson で番号を取り出す
+        run: gh pr merge --auto --merge "${{ fromJson(steps.release.outputs.pr).number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
-          enable-auto-merge: true
+
+      # release-please が PR を作成・更新したときだけ auto-merge を有効化する。
+      # enable-auto-merge は v4 非対応のため、outputs.pr を使って gh コマンドで設定する。
+      - name: Enable auto-merge for release PR
+        if: ${{ steps.release.outputs.pr }}
+        run: gh pr merge --auto --merge "${{ steps.release.outputs.pr }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

release-please が生成する `chore(main): release x.x.x\` PR を毎回手動でマージするのが手間なため自動化する。

## 変更内容

- リポジトリの auto-merge を有効化（GitHub API で設定済み）
- `.github/workflows/release.yml` に `enable-auto-merge: true` を追加

これにより release-please が PR を作成する際に自動で auto-merge が有効になり、
CI が通ったタイミングで自動マージされる。

closes #194