### PR TITLE
fix: release PR の auto-merge が機能しない問題を PAT で解決する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,5 @@ jobs:
         # outputs.pr は JSON オブジェクト文字列のため fromJson で番号を取り出す
         run: gh pr merge --auto --merge "${{ fromJson(steps.release.outputs.pr).number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           release-type: node
 
       # release-please が PR を作成・更新したときだけ auto-merge を有効化する。


### PR DESCRIPTION
## 概要

release PR（`chore(main): release x.x.x`）が open のまま auto-merge されない問題を修正する。

## 根本原因

`GITHUB_TOKEN` で作成した PR は GitHub のセキュリティポリシーにより、
他のワークフロー（CI）をトリガーしない。

そのため必須チェック（`lint-check / lint-check`、`test-build / test-build`）が
実行されず、`gh pr merge --auto` が永遠に待機し続けていた。

**証拠:** `gh pr checks 196` → `no checks reported on the branch`

## 変更内容

release-please-action の `token` を `GITHUB_TOKEN` → `RELEASE_TOKEN`（PAT）に変更。

PAT で作成した PR は CI をトリガーするため、必須チェックが通り auto-merge が動く。

## 副次効果

- issue #197 の残課題（GITHUB_TOKEN で auto-merge すると後続 workflow が起動しない問題）も同時に解決する

closes #200