### PR TITLE
fix: release PR で CI をスキップする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,20 @@ on:
 jobs:
   # audit / type-check / lint を直列で実行（軽量グループ、〜20秒）
   lint-check:
-    # release-please PR は main マージ前に CI 済みのため再実行不要
-    if: "!startsWith(github.head_ref, 'release-please--')"
+    # release-please PR は main マージ前に CI 済みのため再実行不要。
+    # fork PR の偽装を防ぐため head repo が自リポジトリであることも確認する。
+    if: >-
+      !(startsWith(github.head_ref, 'release-please--') &&
+        github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/lint-check.yml
 
   # test:coverage + build を直列で実行（重量グループ、〜60秒）
   test-build:
-    # release-please PR は main マージ前に CI 済みのため再実行不要
-    if: "!startsWith(github.head_ref, 'release-please--')"
+    # release-please PR は main マージ前に CI 済みのため再実行不要。
+    # fork PR の偽装を防ぐため head repo が自リポジトリであることも確認する。
+    if: >-
+      !(startsWith(github.head_ref, 'release-please--') &&
+        github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/test-build.yml
 
   # 両グループ完了後に PR コメントへ表テーブルを投稿

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,19 +35,21 @@ jobs:
   # audit / type-check / lint を直列で実行（軽量グループ、〜20秒）
   lint-check:
     # release-please PR は main マージ前に CI 済みのため再実行不要。
-    # fork PR の偽装を防ぐため head repo が自リポジトリであることも確認する。
+    # fork 偽装防止: head repo + PR 作成者の両方を確認する。
     if: >-
       !(startsWith(github.head_ref, 'release-please--') &&
-        github.event.pull_request.head.repo.full_name == github.repository)
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.login == 'beginerbeginer')
     uses: ./.github/workflows/lint-check.yml
 
   # test:coverage + build を直列で実行（重量グループ、〜60秒）
   test-build:
     # release-please PR は main マージ前に CI 済みのため再実行不要。
-    # fork PR の偽装を防ぐため head repo が自リポジトリであることも確認する。
+    # fork 偽装防止: head repo + PR 作成者の両方を確認する。
     if: >-
       !(startsWith(github.head_ref, 'release-please--') &&
-        github.event.pull_request.head.repo.full_name == github.repository)
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.login == 'beginerbeginer')
     uses: ./.github/workflows/test-build.yml
 
   # 両グループ完了後に PR コメントへ表テーブルを投稿
@@ -100,7 +102,7 @@ jobs:
               coverageDetail = `Lines ${t.lines.pct}% | Stmts ${t.statements.pct}% | Branch ${t.branches.pct}% | Funcs ${t.functions.pct}%`;
             } catch (_) {}
 
-            const allPassed = Object.values(results).every(r => r === 'success');
+            const allPassed = Object.values(results).every(r => r === 'success' || r === 'skipped');
             const headline = allPassed ? '✅ All checks passed' : '❌ Some checks failed';
 
             const body = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,14 @@ on:
 jobs:
   # audit / type-check / lint を直列で実行（軽量グループ、〜20秒）
   lint-check:
+    # release-please PR は main マージ前に CI 済みのため再実行不要
+    if: "!startsWith(github.head_ref, 'release-please--')"
     uses: ./.github/workflows/lint-check.yml
 
   # test:coverage + build を直列で実行（重量グループ、〜60秒）
   test-build:
+    # release-please PR は main マージ前に CI 済みのため再実行不要
+    if: "!startsWith(github.head_ref, 'release-please--')"
     uses: ./.github/workflows/test-build.yml
 
   # 両グループ完了後に PR コメントへ表テーブルを投稿


### PR DESCRIPTION
## 概要

release PR（CHANGELOG + version bump のみ）で CI が再実行されるのを防ぐ。

## 理由

main へのマージ前に CI が通ることが保証されている。
release PR はアプリコードを変えないため、CI を再実行する意味がない。

## 変更内容

ci.yml の lint-check / test-build ジョブに \`if:\` 条件を追加。
\`release-please--\` で始まるブランチからの PR はジョブをスキップする。

GitHub の仕様として \`skipped\` は必須チェックの通過とみなされる（2023年以降）。
→ この PR 自体でスキップが通過扱いになるか検証できる。

closes #202