### PR TITLE
feat: 勝利時に紙吹雪エフェクトを表示する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.2",
       "dependencies": {
         "@mdi/font": "^7.4.47",
+        "canvas-confetti": "^1.9.4",
         "pinia": "^3.0.4",
         "vue": "^3.4.0",
         "vue-router": "^5.0.7",
@@ -18,6 +19,7 @@
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@playwright/test": "^1.60.0",
+        "@types/canvas-confetti": "^1.9.0",
         "@typescript-eslint/eslint-plugin": "^8.59.4",
         "@typescript-eslint/parser": "^8.59.4",
         "@vitejs/plugin-vue": "^6.0.7",
@@ -2459,6 +2461,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -3706,6 +3715,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
       }
     },
     "node_modules/chai": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@mdi/font": "^7.4.47",
+    "canvas-confetti": "^1.9.4",
     "pinia": "^3.0.4",
     "vue": "^3.4.0",
     "vue-router": "^5.0.7",
@@ -40,6 +41,7 @@
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@playwright/test": "^1.60.0",
+    "@types/canvas-confetti": "^1.9.0",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
     "@typescript-eslint/parser": "^8.59.4",
     "@vitejs/plugin-vue": "^6.0.7",

--- a/src/components/reversi/VGame.vue
+++ b/src/components/reversi/VGame.vue
@@ -43,6 +43,7 @@
 
 <script setup lang="ts">
 import { computed, watch, ref } from "vue";
+import confetti from "canvas-confetti";
 import VBoard from "@/components/reversi/VBoard.vue";
 import { useGameStore } from "@/stores/game";
 import { CellState } from "@/models/reversi";
@@ -58,6 +59,15 @@ watch(
   () => store.lastPassed,
   (val) => {
     if (val !== null) showPassNotice.value = true;
+  },
+);
+
+watch(
+  () => store.isGameOver,
+  (val) => {
+    if (val && store.winner !== null) {
+      confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
+    }
   },
 );
 </script>

--- a/tests/integration/VGame.spec.ts
+++ b/tests/integration/VGame.spec.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("canvas-confetti");
 import { mount, flushPromises } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 import { createVuetify } from "vuetify";

--- a/tests/integration/VGame.spec.ts
+++ b/tests/integration/VGame.spec.ts
@@ -1,6 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-
-vi.mock("canvas-confetti");
 import { mount, flushPromises } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 import { createVuetify } from "vuetify";
@@ -8,6 +6,10 @@ import { nextTick } from "vue";
 import VGame from "@/components/reversi/VGame.vue";
 import { useGameStore } from "@/stores/game";
 import { CellState } from "@/models/reversi";
+
+// jsdom は <canvas> を実装しないため canvas-confetti をモックする。
+// npm install canvas で解決する方法もあるが、テスト目的で重い依存を追加するコストに見合わない。
+vi.mock("canvas-confetti");
 
 const vuetify = createVuetify();
 

--- a/tests/unit/VGame.spec.ts
+++ b/tests/unit/VGame.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import { createVuetify } from "vuetify";
+import { useGameStore } from "@/stores/game";
+import { CellState } from "@/models/reversi";
+import VGame from "@/components/reversi/VGame.vue";
+
+const mockConfetti = vi.hoisted(() => vi.fn());
+vi.mock("canvas-confetti", () => ({ default: mockConfetti }));
+
+const vuetify = createVuetify();
+
+describe("VGame", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockConfetti.mockClear();
+    mount(VGame, { global: { plugins: [vuetify] } });
+  });
+
+  it("ゲームが終了して黒が勝った場合、confetti が呼ばれる", async () => {
+    const store = useGameStore();
+    store.board.rows.forEach((row) =>
+      row.cells.forEach((cell) => (cell.state = CellState.Black)),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockConfetti).toHaveBeenCalledOnce();
+  });
+
+  it("ゲームが終了して白が勝った場合、confetti が呼ばれる", async () => {
+    const store = useGameStore();
+    store.board.rows.forEach((row) =>
+      row.cells.forEach((cell) => (cell.state = CellState.White)),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockConfetti).toHaveBeenCalledOnce();
+  });
+
+  it("ゲームが終了していない状態では confetti が呼ばれない", async () => {
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockConfetti).not.toHaveBeenCalled();
+  });
+
+  it("引き分けの場合、confetti が呼ばれない", async () => {
+    const store = useGameStore();
+    let count = 0;
+    store.board.rows.forEach((row) =>
+      row.cells.forEach((cell) => {
+        cell.state = count++ < 32 ? CellState.Black : CellState.White;
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockConfetti).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

- 勝利者が決まったとき `canvas-confetti` で紙吹雪を表示する
- 引き分けの場合は confetti を発火しない

## テスト

TDD（Red → Green → Refactor）で実装。`tests/unit/VGame.spec.ts` を新規追加：

- 黒が勝った場合 → confetti が呼ばれる
- 白が勝った場合 → confetti が呼ばれる
- ゲーム中（終了前）→ confetti が呼ばれない
- 引き分け → confetti が呼ばれない

closes #125