### PR TITLE
feat: ゲーム開始前のモード選択で待った機能を有効化できるようにする

### DIFF
--- a/src/components/VMain.vue
+++ b/src/components/VMain.vue
@@ -1,7 +1,20 @@
 <template>
   <v-container fluid>
+    <div class="d-flex justify-center mb-4">
+      <v-checkbox
+        v-model="allowUndoEnabled"
+        label="待った機能を有効にする"
+        data-testid="allow-undo-checkbox"
+        hide-details
+      />
+    </div>
     <div class="d-flex justify-center">
-      <v-btn color="primary" variant="outlined" @click="router.push('/game')">
+      <v-btn
+        color="primary"
+        variant="outlined"
+        data-testid="start-button"
+        @click="startGame"
+      >
         ゲームスタート！！
       </v-btn>
     </div>
@@ -9,6 +22,16 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import { useRouter } from "vue-router";
+import { useGameStore } from "@/stores/game";
+
 const router = useRouter();
+const store = useGameStore();
+const allowUndoEnabled = ref(false);
+
+function startGame() {
+  store.startGame({ allowUndo: allowUndoEnabled.value });
+  router.push("/game");
+}
 </script>

--- a/src/components/reversi/VGame.vue
+++ b/src/components/reversi/VGame.vue
@@ -12,6 +12,16 @@
     <div class="d-flex justify-center">
       <h1>黒の石：{{ store.board.blacks }}</h1>
     </div>
+    <div v-if="store.allowUndo" class="d-flex justify-center mt-2">
+      <v-btn
+        data-testid="undo-button"
+        :disabled="!store.canUndo"
+        variant="outlined"
+        @click="store.undo()"
+      >
+        待った
+      </v-btn>
+    </div>
     <v-dialog v-model="store.isGameOver" persistent max-width="400">
       <v-card>
         <v-card-title class="text-h5 text-center pt-6">ゲーム終了</v-card-title>
@@ -24,7 +34,12 @@
           </div>
         </v-card-text>
         <v-card-actions class="justify-center pb-4">
-          <v-btn color="primary" variant="elevated" @click="store.reset()">
+          <v-btn
+            data-testid="retry-button"
+            color="primary"
+            variant="elevated"
+            @click="router.push('/')"
+          >
             もう一度
           </v-btn>
         </v-card-actions>
@@ -43,12 +58,14 @@
 
 <script setup lang="ts">
 import { computed, watch, ref } from "vue";
+import { useRouter } from "vue-router";
 import confetti from "canvas-confetti";
 import VBoard from "@/components/reversi/VBoard.vue";
 import { useGameStore } from "@/stores/game";
 import { CellState } from "@/models/reversi";
 
 const store = useGameStore();
+const router = useRouter();
 const showPassNotice = ref(false);
 
 const passMessage = computed(() =>

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -5,6 +5,12 @@ import { Board, CellState, Point } from "@/models/reversi";
 export const useGameStore = defineStore("game", () => {
   const board = reactive(new Board());
   const lastPassed = ref<CellState | null>(null);
+  const allowUndo = ref(false);
+  const history = ref<{ rows: { state: CellState }[][]; turn: CellState }[]>(
+    [],
+  );
+
+  const canUndo = computed(() => allowUndo.value && history.value.length > 0);
 
   const current = computed(() =>
     board.turn === CellState.Black ? "黒の手番" : "白の手番",
@@ -30,6 +36,23 @@ export const useGameStore = defineStore("game", () => {
     return null;
   });
 
+  function startGame(options: { allowUndo: boolean }) {
+    allowUndo.value = options.allowUndo;
+    reset();
+  }
+
+  function undo() {
+    if (!canUndo.value) return;
+    const snapshot = history.value.pop()!;
+    board.turn = snapshot.turn;
+    board.rows.forEach((row, i) => {
+      row.cells.forEach((cell, j) => {
+        cell.state = snapshot.rows[i][j].state;
+      });
+    });
+    lastPassed.value = null;
+  }
+
   function reset() {
     const fresh = new Board();
     board.turn = fresh.turn;
@@ -39,12 +62,22 @@ export const useGameStore = defineStore("game", () => {
       });
     });
     lastPassed.value = null;
+    history.value = [];
   }
 
   function put(x: number, y: number) {
     const p = new Point(x, y);
     const turnBefore = board.turn;
     const wasEmpty = board.ref(p).isNone;
+
+    if (allowUndo.value) {
+      history.value.push({
+        rows: board.rows.map((row) =>
+          row.cells.map((c) => ({ state: c.state })),
+        ),
+        turn: board.turn,
+      });
+    }
 
     board.put(p);
 
@@ -67,5 +100,9 @@ export const useGameStore = defineStore("game", () => {
     isGameOver,
     winner,
     validMoves,
+    allowUndo,
+    canUndo,
+    startGame,
+    undo,
   };
 });

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -70,18 +70,21 @@ export const useGameStore = defineStore("game", () => {
     const turnBefore = board.turn;
     const wasEmpty = board.ref(p).isNone;
 
-    if (allowUndo.value) {
-      history.value.push({
-        rows: board.rows.map((row) =>
-          row.cells.map((c) => ({ state: c.state })),
-        ),
-        turn: board.turn,
-      });
-    }
+    const snapshot = allowUndo.value
+      ? {
+          rows: board.rows.map((row) =>
+            row.cells.map((c) => ({ state: c.state })),
+          ),
+          turn: board.turn,
+        }
+      : null;
 
     board.put(p);
 
     const stonePlaced = wasEmpty && !board.ref(p).isNone;
+    if (snapshot && stonePlaced) {
+      history.value.push(snapshot);
+    }
     // 石が置かれたのにターンが戻ってきた = 相手がパスされた
     if (stonePlaced && board.turn === turnBefore) {
       lastPassed.value =

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -65,7 +65,7 @@ test.describe("リバーシ ゲーム画面", () => {
     await expect(page.getByText(/黒 \d+ 対 白 \d+/)).toBeVisible();
   });
 
-  test("「もう一度」ボタンでゲームが初期状態に戻り再プレイできる", async ({
+  test("「もう一度」ボタンでゲームスタート画面に戻り、再スタートで初期状態から再プレイできる", async ({
     page,
   }) => {
     const cells = page.locator(".cell-wrapper");
@@ -75,6 +75,13 @@ test.describe("リバーシ ゲーム画面", () => {
     }
     await page.getByRole("button", { name: "もう一度" }).click();
 
+    // スタート画面に戻ることを確認
+    await expect(
+      page.getByRole("button", { name: "ゲームスタート！！" }),
+    ).toBeVisible();
+
+    // 再スタートして初期状態になることを確認
+    await page.getByRole("button", { name: "ゲームスタート！！" }).click();
     await expect(page.locator(".white-stone")).toHaveCount(2);
     await expect(page.locator(".black-stone")).toHaveCount(2);
     await expect(page.getByText("黒の手番")).toBeVisible();

--- a/tests/integration/VGame.spec.ts
+++ b/tests/integration/VGame.spec.ts
@@ -3,6 +3,7 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 import { createVuetify } from "vuetify";
 import { nextTick } from "vue";
+import { createRouter, createMemoryHistory } from "vue-router";
 import VGame from "@/components/reversi/VGame.vue";
 import { useGameStore } from "@/stores/game";
 import { CellState } from "@/models/reversi";
@@ -24,11 +25,19 @@ function fillBoard(
 
 describe("VGame", () => {
   let wrapper: ReturnType<typeof mount>;
+  let router: ReturnType<typeof createRouter>;
 
   beforeEach(() => {
     setActivePinia(createPinia());
+    router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: "/", component: {} },
+        { path: "/game", component: VGame },
+      ],
+    });
     wrapper = mount(VGame, {
-      global: { plugins: [vuetify] },
+      global: { plugins: [vuetify, router] },
       attachTo: document.body,
     });
   });
@@ -98,20 +107,19 @@ describe("VGame", () => {
       expect(document.body.textContent).toContain("引き分け");
     });
 
-    it("「もう一度」ボタンで手番・スコアが初期状態に戻る", async () => {
+    it("「もう一度」ボタンでスタート画面（/）へ遷移する", async () => {
       const store = useGameStore();
       fillBoard(store, CellState.Black);
       await nextTick();
 
+      const pushSpy = vi.spyOn(router, "push");
       const btn = document.body.querySelector<HTMLButtonElement>(
         ".v-overlay-container button",
       );
       btn?.click();
       await nextTick();
 
-      expect(wrapper.text()).toContain("黒の手番");
-      expect(wrapper.text()).toContain("白の石：2");
-      expect(wrapper.text()).toContain("黒の石：2");
+      expect(pushSpy).toHaveBeenCalledWith("/");
     });
   });
 

--- a/tests/unit/VGame.spec.ts
+++ b/tests/unit/VGame.spec.ts
@@ -7,6 +7,11 @@ import { useGameStore } from "@/stores/game";
 import { CellState } from "@/models/reversi";
 import VGame from "@/components/reversi/VGame.vue";
 
+const mockPush = vi.fn();
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 const mockConfetti = vi.hoisted(() => vi.fn());
 vi.mock("canvas-confetti", () => ({ default: mockConfetti }));
 
@@ -16,7 +21,62 @@ describe("VGame", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockConfetti.mockClear();
+    mockPush.mockClear();
     mount(VGame, { global: { plugins: [vuetify] } });
+  });
+
+  describe("もう一度ボタン", () => {
+    it("もう一度ボタンをクリックすると / に遷移する", async () => {
+      const store = useGameStore();
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      mount(VGame, {
+        attachTo: document.body,
+        global: { plugins: [vuetify] },
+      });
+      await nextTick();
+      await nextTick();
+      const btn = document.querySelector(
+        "[data-testid='retry-button']",
+      ) as HTMLElement;
+      btn.click();
+      await nextTick();
+      expect(mockPush).toHaveBeenCalledWith("/");
+    });
+  });
+
+  describe("待ったボタン", () => {
+    it("allowUndo: false のとき待ったボタンが表示されない", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: false });
+      const wrapper = mount(VGame, { global: { plugins: [vuetify] } });
+      expect(wrapper.find("[data-testid='undo-button']").exists()).toBe(false);
+    });
+
+    it("allowUndo: true のとき待ったボタンが表示される", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      const wrapper = mount(VGame, { global: { plugins: [vuetify] } });
+      expect(wrapper.find("[data-testid='undo-button']").exists()).toBe(true);
+    });
+
+    it("allowUndo: true かつ canUndo: false のとき待ったボタンが disabled", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      const wrapper = mount(VGame, { global: { plugins: [vuetify] } });
+      const btn = wrapper.find("[data-testid='undo-button']");
+      expect(btn.attributes("disabled")).toBeDefined();
+    });
+
+    it("allowUndo: true かつ canUndo: true のとき待ったボタンをクリックで undo が呼ばれる", async () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      store.put(3, 2);
+      const wrapper = mount(VGame, { global: { plugins: [vuetify] } });
+      await wrapper.find("[data-testid='undo-button']").trigger("click");
+      expect(store.canUndo).toBe(false); // undo 後は履歴が空
+    });
   });
 
   it("ゲームが終了して黒が勝った場合、confetti が呼ばれる", async () => {

--- a/tests/unit/VMain.spec.ts
+++ b/tests/unit/VMain.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import { createVuetify } from "vuetify";
+import { useGameStore } from "@/stores/game";
+import VMain from "@/components/VMain.vue";
+
+const mockPush = vi.fn();
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const vuetify = createVuetify();
+
+describe("VMain", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockPush.mockClear();
+  });
+
+  it("「待った機能を有効にする」チェックボックスが存在する", () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    expect(wrapper.find("[data-testid='allow-undo-checkbox']").exists()).toBe(
+      true,
+    );
+  });
+
+  it("チェックをONにしてスタートすると allowUndo: true で startGame が呼ばれ /game に遷移する", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    const checkbox = wrapper.find(
+      "[data-testid='allow-undo-checkbox'] input[type='checkbox']",
+    );
+    await checkbox.setValue(true);
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.allowUndo).toBe(true);
+    expect(mockPush).toHaveBeenCalledWith("/game");
+  });
+
+  it("チェックをOFFのままスタートすると allowUndo: false で startGame が呼ばれ /game に遷移する", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.allowUndo).toBe(false);
+    expect(mockPush).toHaveBeenCalledWith("/game");
+  });
+});

--- a/tests/unit/gameStore.spec.ts
+++ b/tests/unit/gameStore.spec.ts
@@ -187,6 +187,22 @@ describe("useGameStore", () => {
       store.undo();
       expect(store.canUndo).toBe(false);
     });
+
+    it("allowUndo: true のとき、無効なマス（石が置けない）をクリックしても canUndo は false のまま", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      store.put(0, 0); // 初期盤面で (0,0) は置けない無効な手
+      expect(store.canUndo).toBe(false);
+    });
+
+    it("allowUndo: true のとき、有効な手の後に無効なマスをクリックしても履歴は増えない", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      store.put(3, 2); // 有効な手
+      store.put(0, 0); // 無効な手
+      store.undo(); // 1回 undo
+      expect(store.canUndo).toBe(false); // 履歴が空になっているはず
+    });
   });
 
   describe("lastPassed", () => {

--- a/tests/unit/gameStore.spec.ts
+++ b/tests/unit/gameStore.spec.ts
@@ -69,6 +69,14 @@ describe("useGameStore", () => {
   });
 
   describe("reset", () => {
+    it("allowUndo: true のとき、reset を呼ぶと canUndo が false になる", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      store.put(3, 2);
+      store.reset();
+      expect(store.canUndo).toBe(false);
+    });
+
     it("reset を呼ぶと石が初期配置に戻る", () => {
       const store = useGameStore();
       store.put(3, 2);
@@ -104,6 +112,80 @@ describe("useGameStore", () => {
       );
       store.reset();
       expect(store.isGameOver).toBe(false);
+    });
+  });
+
+  describe("allowUndo / startGame", () => {
+    it("allowUndo のデフォルト値は false", () => {
+      const store = useGameStore();
+      expect(store.allowUndo).toBe(false);
+    });
+
+    it("startGame({ allowUndo: true }) を呼ぶと allowUndo が true になる", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      expect(store.allowUndo).toBe(true);
+    });
+
+    it("startGame({ allowUndo: false }) を呼ぶと allowUndo が false のまま", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: false });
+      expect(store.allowUndo).toBe(false);
+    });
+
+    it("startGame を呼ぶと盤面が初期状態（黒2・白2）に戻る", () => {
+      const store = useGameStore();
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      store.startGame({ allowUndo: false });
+      expect(store.board.blacks).toBe(2);
+      expect(store.board.whites).toBe(2);
+    });
+
+    it("allowUndo: false のとき、put 後も canUndo は false", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: false });
+      store.put(3, 2);
+      expect(store.canUndo).toBe(false);
+    });
+
+    it("allowUndo: true のとき、初期状態では canUndo は false", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      expect(store.canUndo).toBe(false);
+    });
+
+    it("allowUndo: true のとき、put 後に canUndo が true になる", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      store.put(3, 2);
+      expect(store.canUndo).toBe(true);
+    });
+
+    it("allowUndo: true のとき、undo() を呼ぶと盤面が1手前に戻る", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      const blacksBefore = store.board.blacks;
+      store.put(3, 2);
+      store.undo();
+      expect(store.board.blacks).toBe(blacksBefore);
+    });
+
+    it("allowUndo: true のとき、undo() を呼ぶと手番が1手前に戻る", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      store.put(3, 2); // 黒が打つ → 白の手番
+      store.undo();
+      expect(store.current).toBe("黒の手番");
+    });
+
+    it("allowUndo: true のとき、undo() 後に canUndo が false になる（履歴が空）", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      store.put(3, 2);
+      store.undo();
+      expect(store.canUndo).toBe(false);
     });
   });
 


### PR DESCRIPTION
## 変更内容

- スタート画面（VMain）に「待った機能を有効にする」チェックボックスを追加
- チェックをONにしてゲームスタートすると、ゲーム中に「待った」ボタンが表示される
- 「待った」ボタンをクリックすると直前の1手が取り消される
- ゲーム終了時の「もう一度」ボタンをスタート画面（`/`）へ遷移するよう変更
- `startGame()` 呼び出し時に盤面を初期化するよう変更

closes #52

## 動作確認チェックリスト

- [x] スタート画面に「待った機能を有効にする」チェックボックスが表示される
- [x] チェックOFFでスタート → ゲーム画面に「待った」ボタンが表示されない
- [x] チェックONでスタート → ゲーム画面に「待った」ボタンが表示される
- [x] 1手も打っていない状態では「待った」ボタンが disabled
- [x] 石を置いた後「待った」をクリックすると1手前に戻る
- [x] ゲーム終了後「もう一度」をクリックするとスタート画面に戻る
- [x] スタート画面から再スタートすると盤面がリセットされている