### PR TITLE
fix: ゲームオーバー時にパス通知が表示されないようにする

### DIFF
--- a/src/components/reversi/VGame.vue
+++ b/src/components/reversi/VGame.vue
@@ -34,6 +34,7 @@
           </div>
         </v-card-text>
         <v-card-actions class="justify-center pb-4">
+          <!-- 盤面リセットはスタート画面の startGame() が担う。ここでは遷移のみ行う。 -->
           <v-btn
             data-testid="retry-button"
             color="primary"
@@ -68,14 +69,20 @@ const store = useGameStore();
 const router = useRouter();
 const showPassNotice = ref(false);
 
-const passMessage = computed(() =>
-  store.lastPassed === CellState.Black ? "黒はパスです" : "白はパスです",
-);
+const passMessage = computed(() => {
+  if (store.lastPassed === CellState.Black) return "黒はパスです";
+  if (store.lastPassed === CellState.White) return "白はパスです";
+  return "";
+});
 
 watch(
   () => store.lastPassed,
   (val) => {
-    if (val !== null) showPassNotice.value = true;
+    if (val !== null) {
+      showPassNotice.value = true;
+    } else {
+      showPassNotice.value = false;
+    }
   },
 );
 

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -2,13 +2,13 @@ import { reactive, computed, ref, toRaw } from "vue";
 import { defineStore } from "pinia";
 import { Board, CellState, Point } from "@/models/reversi";
 
+type BoardSnapshot = { rows: { state: CellState }[][]; turn: CellState };
+
 export const useGameStore = defineStore("game", () => {
   const board = reactive(new Board());
   const lastPassed = ref<CellState | null>(null);
   const allowUndo = ref(false);
-  const history = ref<{ rows: { state: CellState }[][]; turn: CellState }[]>(
-    [],
-  );
+  const history = ref<BoardSnapshot[]>([]);
 
   const canUndo = computed(() => allowUndo.value && history.value.length > 0);
 
@@ -98,7 +98,6 @@ export const useGameStore = defineStore("game", () => {
     board,
     current,
     put,
-    reset,
     lastPassed,
     isGameOver,
     winner,

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -92,6 +92,10 @@ export const useGameStore = defineStore("game", () => {
     } else {
       lastPassed.value = null;
     }
+    // ゲームオーバー時はパス通知ではなく勝敗ダイアログのみ表示する
+    if (isGameOver.value) {
+      lastPassed.value = null;
+    }
   }
 
   return {

--- a/tests/e2e/game.spec.ts
+++ b/tests/e2e/game.spec.ts
@@ -109,7 +109,7 @@ test.describe("リバーシ ゲーム画面", () => {
 
   test("パス時にスナックバーが表示され手番が変わる", async ({ page }) => {
     // 黒がパスになる局面: 行7以外を黒で埋め、行7は [W,_,B,B,B,W,B,B]
-    // この状態で白が (1,7) に置くと黒が挟まれずパスになる
+    // 左上隅を空けることで、白の (1,7) put 後もゲームオーバーにならずパス通知が出る（#212）
     await page.evaluate(() => {
       const store = (
         document.querySelector("#app") as any
@@ -122,6 +122,7 @@ test.describe("リバーシ ゲーム画面", () => {
       store.board.rows[7].cells[0].state = "white";
       store.board.rows[7].cells[1].state = "none";
       store.board.rows[7].cells[5].state = "white";
+      store.board.rows[0].cells[0].state = "none";
       store.board.turn = "white";
     });
 

--- a/tests/integration/VGame.spec.ts
+++ b/tests/integration/VGame.spec.ts
@@ -126,11 +126,17 @@ describe("VGame", () => {
   describe("パス通知スナックバー", () => {
     it("パスが発生したとき「白はパスです」スナックバーが表示される", async () => {
       const store = useGameStore();
-      // 全マス黒で埋め (0,0) のみ空き・(1,0) を白にして黒番にする
-      // → 黒が (0,0) に置くと (1,0) が反転し白は置けずパスになる
+      // ゲームオーバーにならない「白パス」の盤面を作る
+      // (0,0)=空き、(0,1)=白、(0,2)=黒 → 黒は (0,0) に置ける
+      // (0,3)=空き、(0,4)=白、(0,5)=黒 → put 後も黒は (0,3) に置けるのでゲームオーバーにならない
+      // 残りはすべて黒
       fillBoard(store, CellState.Black);
       store.board.rows[0].cells[0].state = CellState.None;
       store.board.rows[0].cells[1].state = CellState.White;
+      // (0,2) は黒のまま
+      store.board.rows[0].cells[3].state = CellState.None;
+      store.board.rows[0].cells[4].state = CellState.White;
+      // (0,5) は黒のまま
       store.board.turn = CellState.Black;
 
       store.put(0, 0);

--- a/tests/unit/gameStore.spec.ts
+++ b/tests/unit/gameStore.spec.ts
@@ -219,8 +219,31 @@ describe("useGameStore", () => {
 
     it("オートパスが発生したとき、パスされた側の色が入る", () => {
       const store = useGameStore();
-      // 黒が (0,0) に置いたら白がパスになる盤面を作る
-      // 全マス黒で埋めて (0,0) だけ空け、(1,0) を白にする
+      // 黒が (0,0) に置いたら白がパスになるが、ゲームオーバーではない盤面を作る
+      // (0,0)=空き、(0,1)=白、(0,2)=黒 → 黒は (0,0) に置ける
+      // (0,3)=空き、(0,4)=白、(0,5)=黒 → put 後も黒は (0,3) に置けるのでゲームオーバーにならない
+      // 残りはすべて黒
+      store.board.rows.forEach((row) =>
+        row.cells.forEach((cell) => (cell.state = CellState.Black)),
+      );
+      store.board.rows[0].cells[0].state = CellState.None;
+      store.board.rows[0].cells[1].state = CellState.White;
+      // (0,2) は黒のまま
+      store.board.rows[0].cells[3].state = CellState.None;
+      store.board.rows[0].cells[4].state = CellState.White;
+      // (0,5) は黒のまま
+      store.board.turn = CellState.Black;
+
+      store.put(0, 0); // 黒 → (0,1) 反転 → 白は置けずパス → 黒の手番に戻る（ゲームオーバーなし）
+
+      expect(store.isGameOver).toBe(false); // ゲームオーバーでないことを保証
+      expect(store.lastPassed).toBe(CellState.White);
+    });
+
+    it("ゲームオーバーと同時にオートパスが発生しても lastPassed は null になる", () => {
+      const store = useGameStore();
+      // 全マス黒で埋め (0,0) だけ空け、(1,0) を白にする
+      // → 黒が (0,0) に置く → (1,0) が反転 → 全マス黒 → ゲームオーバー
       store.board.rows.forEach((row) =>
         row.cells.forEach((cell) => (cell.state = CellState.Black)),
       );
@@ -228,9 +251,10 @@ describe("useGameStore", () => {
       store.board.rows[0].cells[1].state = CellState.White;
       store.board.turn = CellState.Black;
 
-      store.put(0, 0); // 黒が (0,0) に置く → (1,0) が反転 → 白は置く場所がなくパス
+      store.put(0, 0);
 
-      expect(store.lastPassed).toBe(CellState.White);
+      expect(store.isGameOver).toBe(true); // ゲームオーバーであることを保証
+      expect(store.lastPassed).toBeNull(); // パス通知は出さない
     });
   });
 });

--- a/tests/unit/gameStore.spec.ts
+++ b/tests/unit/gameStore.spec.ts
@@ -68,31 +68,31 @@ describe("useGameStore", () => {
     });
   });
 
-  describe("reset", () => {
-    it("allowUndo: true のとき、reset を呼ぶと canUndo が false になる", () => {
+  describe("reset (startGame 経由)", () => {
+    it("allowUndo: true のとき、startGame を呼ぶと canUndo が false になる", () => {
       const store = useGameStore();
       store.startGame({ allowUndo: true });
       store.put(3, 2);
-      store.reset();
+      store.startGame({ allowUndo: false });
       expect(store.canUndo).toBe(false);
     });
 
-    it("reset を呼ぶと石が初期配置に戻る", () => {
+    it("startGame を呼ぶと石が初期配置に戻る", () => {
       const store = useGameStore();
       store.put(3, 2);
-      store.reset();
+      store.startGame({ allowUndo: false });
       expect(store.board.blacks).toBe(2);
       expect(store.board.whites).toBe(2);
     });
 
-    it("reset を呼ぶと黒の手番に戻る", () => {
+    it("startGame を呼ぶと黒の手番に戻る", () => {
       const store = useGameStore();
       store.put(3, 2);
-      store.reset();
+      store.startGame({ allowUndo: false });
       expect(store.current).toBe("黒の手番");
     });
 
-    it("reset を呼ぶと lastPassed が null になる", () => {
+    it("startGame を呼ぶと lastPassed が null になる", () => {
       const store = useGameStore();
       store.board.rows.forEach((row) =>
         row.cells.forEach((cell) => (cell.state = CellState.Black)),
@@ -101,16 +101,16 @@ describe("useGameStore", () => {
       store.board.rows[0].cells[1].state = CellState.White;
       store.board.turn = CellState.Black;
       store.put(0, 0);
-      store.reset();
+      store.startGame({ allowUndo: false });
       expect(store.lastPassed).toBeNull();
     });
 
-    it("reset を呼ぶとゲームオーバーが解除される", () => {
+    it("startGame を呼ぶとゲームオーバーが解除される", () => {
       const store = useGameStore();
       store.board.rows.forEach((row) =>
         row.cells.forEach((cell) => (cell.state = CellState.Black)),
       );
-      store.reset();
+      store.startGame({ allowUndo: false });
       expect(store.isGameOver).toBe(false);
     });
   });


### PR DESCRIPTION
## 変更内容

- ゲームオーバーと同時にオートパスが発生した場合、`lastPassed` を null にリセットしてパス通知スナックバーを抑制する
- `passMessage` computed に `CellState.White` の分岐を追加し、`null` の場合は空文字を返すよう修正
- `showPassNotice` の watch で `lastPassed` が null になったとき false に戻すよう修正
- `reset()` を store の公開 API から除外し、`startGame()` 経由でのみリセットできるようにした
- E2E テストのパス通知盤面をゲームオーバーにならない局面に修正

closes #212

## 動作確認チェックリスト

- [x] 通常のパス発生時にスナックバーが表示される
- [x] ゲームオーバーと同時にパスが発生してもスナックバーが表示されない
- [x] ユニットテスト・統合テスト・E2E テスト全件パス