### PR TITLE
chore: release-please auto-merge 後にリリースブランチを自動削除する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Enable auto-merge for release PR
         if: ${{ steps.release.outputs.pr }}
         # outputs.pr は JSON オブジェクト文字列のため fromJson で番号を取り出す
-        run: gh pr merge --auto --merge "${{ fromJson(steps.release.outputs.pr).number }}"
+        run: gh pr merge --auto --merge --delete-branch "${{ fromJson(steps.release.outputs.pr).number }}"
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- `gh pr merge --auto --merge` に `--delete-branch` フラグを追加
- release-please が作成した PR が auto-merge されたタイミングでリモートブランチを自動削除する

## Test plan

- [ ] 次回 release-please PR がマージされた後、`release-please--branches--main--components--reversi` ブランチが自動削除されることを確認する

closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)