### PR TITLE
docs(store): スナップショット取得のディープコピー実装に Why not コメントを追加する

### DIFF
--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -70,6 +70,8 @@ export const useGameStore = defineStore("game", () => {
     const turnBefore = board.turn;
     const wasEmpty = board.ref(p).isNone;
 
+    // { state: c.state } で新オブジェクトを生成する。cell 参照ごと保存すると
+    // reactive な参照を共有してしまい、undo 後に現在の盤面が書き換わるため
     const snapshot = allowUndo.value
       ? {
           rows: board.rows.map((row) =>


### PR DESCRIPTION
## 何をしたか

`game.ts` の `BoardSnapshot` 生成箇所に Why not コメントを追加。

## なぜしたか

issue #217 でディープコピー実装の正確性について懸念が挙がった。
調査の結果バグは存在しないが、`{ state: c.state }` のパターンが
参照コピーと見間違えやすいため、コメントで意図を明示する。

## テスト確認

- [x] `npm run test:unit` が通ることを確認した
- [x] `npm run type-check` が通ることを確認した
- [x] `npm run lint` が通ることを確認した
- [x] 変更に対応するテストを追加した（または追加不要な理由を記載）
  - コメント追加のみ。ロジック変更なし。

closes #217