### PR TITLE
refactor(components): ゲーム内 UI を VGame.vue から3コンポーネントに分割する

### DIFF
--- a/src/components/reversi/VGame.vue
+++ b/src/components/reversi/VGame.vue
@@ -3,95 +3,18 @@
     <div class="d-flex justify-center">
       <VBoard :board="store.board" />
     </div>
-    <div class="d-flex justify-center">
-      <h1>{{ store.current }}</h1>
-    </div>
-    <div class="d-flex justify-center">
-      <h1>白の石：{{ store.board.whites }}</h1>
-    </div>
-    <div class="d-flex justify-center">
-      <h1>黒の石：{{ store.board.blacks }}</h1>
-    </div>
-    <div v-if="store.allowUndo" class="d-flex justify-center mt-2">
-      <v-btn
-        data-testid="undo-button"
-        :disabled="!store.canUndo"
-        variant="outlined"
-        @click="store.undo()"
-      >
-        待った
-      </v-btn>
-    </div>
-    <v-dialog v-model="store.isGameOver" persistent max-width="400">
-      <v-card>
-        <v-card-title class="text-h5 text-center pt-6">ゲーム終了</v-card-title>
-        <v-card-text class="text-center text-h6">
-          <span v-if="store.winner === CellState.Black">黒の勝ち 🎉</span>
-          <span v-else-if="store.winner === CellState.White">白の勝ち 🎉</span>
-          <span v-else>引き分け</span>
-          <div class="mt-2 text-body-1">
-            黒 {{ store.board.blacks }} 対 白 {{ store.board.whites }}
-          </div>
-        </v-card-text>
-        <v-card-actions class="justify-center pb-4">
-          <!-- 盤面リセットはスタート画面の startGame() が担う。ここでは遷移のみ行う。 -->
-          <v-btn
-            data-testid="retry-button"
-            color="primary"
-            variant="elevated"
-            @click="router.push('/')"
-          >
-            もう一度
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-    <v-snackbar
-      v-model="showPassNotice"
-      :timeout="3000"
-      color="info"
-      location="top"
-    >
-      {{ passMessage }}
-    </v-snackbar>
+    <VGameScore />
+    <VGameOver />
+    <VPassNotice />
   </v-container>
 </template>
 
 <script setup lang="ts">
-import { computed, watch, ref } from "vue";
-import { useRouter } from "vue-router";
-import confetti from "canvas-confetti";
 import VBoard from "@/components/reversi/VBoard.vue";
+import VGameScore from "@/components/reversi/VGameScore.vue";
+import VGameOver from "@/components/reversi/VGameOver.vue";
+import VPassNotice from "@/components/reversi/VPassNotice.vue";
 import { useGameStore } from "@/stores/game";
-import { CellState } from "@/models/reversi";
 
 const store = useGameStore();
-const router = useRouter();
-const showPassNotice = ref(false);
-
-const passMessage = computed(() => {
-  if (store.lastPassed === CellState.Black) return "黒はパスです";
-  if (store.lastPassed === CellState.White) return "白はパスです";
-  return "";
-});
-
-watch(
-  () => store.lastPassed,
-  (val) => {
-    if (val !== null) {
-      showPassNotice.value = true;
-    } else {
-      showPassNotice.value = false;
-    }
-  },
-);
-
-watch(
-  () => store.isGameOver,
-  (val) => {
-    if (val && store.winner !== null) {
-      confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
-    }
-  },
-);
 </script>

--- a/src/components/reversi/VGameOver.vue
+++ b/src/components/reversi/VGameOver.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-dialog v-model="store.isGameOver" persistent max-width="400">
+    <v-card>
+      <v-card-title class="text-h5 text-center pt-6">ゲーム終了</v-card-title>
+      <v-card-text class="text-center text-h6">
+        <span v-if="store.winner === CellState.Black">黒の勝ち 🎉</span>
+        <span v-else-if="store.winner === CellState.White">白の勝ち 🎉</span>
+        <span v-else>引き分け</span>
+        <div class="mt-2 text-body-1">
+          黒 {{ store.board.blacks }} 対 白 {{ store.board.whites }}
+        </div>
+      </v-card-text>
+      <v-card-actions class="justify-center pb-4">
+        <!-- 盤面リセットはスタート画面の startGame() が担う。ここでは遷移のみ行う。 -->
+        <v-btn
+          data-testid="retry-button"
+          color="primary"
+          variant="elevated"
+          @click="router.push('/')"
+        >
+          もう一度
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { watch } from "vue";
+import { useRouter } from "vue-router";
+import confetti from "canvas-confetti";
+import { useGameStore } from "@/stores/game";
+import { CellState } from "@/models/reversi";
+
+const store = useGameStore();
+const router = useRouter();
+
+watch(
+  () => store.isGameOver,
+  (val) => {
+    if (val && store.winner !== null) {
+      confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
+    }
+  },
+);
+</script>

--- a/src/components/reversi/VGameScore.vue
+++ b/src/components/reversi/VGameScore.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <div class="d-flex justify-center">
+      <h1>{{ store.current }}</h1>
+    </div>
+    <div class="d-flex justify-center">
+      <h1>白の石：{{ store.board.whites }}</h1>
+    </div>
+    <div class="d-flex justify-center">
+      <h1>黒の石：{{ store.board.blacks }}</h1>
+    </div>
+    <div v-if="store.allowUndo" class="d-flex justify-center mt-2">
+      <v-btn
+        data-testid="undo-button"
+        :disabled="!store.canUndo"
+        variant="outlined"
+        @click="store.undo()"
+      >
+        待った
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useGameStore } from "@/stores/game";
+
+const store = useGameStore();
+</script>

--- a/src/components/reversi/VPassNotice.vue
+++ b/src/components/reversi/VPassNotice.vue
@@ -1,0 +1,32 @@
+<template>
+  <v-snackbar
+    v-model="showPassNotice"
+    :timeout="3000"
+    color="info"
+    location="top"
+  >
+    {{ passMessage }}
+  </v-snackbar>
+</template>
+
+<script setup lang="ts">
+import { computed, watch, ref } from "vue";
+import { useGameStore } from "@/stores/game";
+import { CellState } from "@/models/reversi";
+
+const store = useGameStore();
+const showPassNotice = ref(false);
+
+const passMessage = computed(() => {
+  if (store.lastPassed === CellState.Black) return "黒はパスです";
+  if (store.lastPassed === CellState.White) return "白はパスです";
+  return "";
+});
+
+watch(
+  () => store.lastPassed,
+  (val) => {
+    showPassNotice.value = val !== null;
+  },
+);
+</script>

--- a/tests/unit/VGameOver.spec.ts
+++ b/tests/unit/VGameOver.spec.ts
@@ -5,7 +5,7 @@ import { setActivePinia, createPinia } from "pinia";
 import { createVuetify } from "vuetify";
 import { useGameStore } from "@/stores/game";
 import { CellState } from "@/models/reversi";
-import VGame from "@/components/reversi/VGame.vue";
+import VGameOver from "@/components/reversi/VGameOver.vue";
 
 const mockPush = vi.fn();
 vi.mock("vue-router", () => ({
@@ -17,12 +17,12 @@ vi.mock("canvas-confetti", () => ({ default: mockConfetti }));
 
 const vuetify = createVuetify();
 
-describe("VGame", () => {
+describe("VGameOver", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockConfetti.mockClear();
     mockPush.mockClear();
-    mount(VGame, { global: { plugins: [vuetify] } });
+    mount(VGameOver, { global: { plugins: [vuetify] } });
   });
 
   describe("もう一度ボタン", () => {
@@ -31,7 +31,7 @@ describe("VGame", () => {
       store.board.rows.forEach((row) =>
         row.cells.forEach((cell) => (cell.state = CellState.Black)),
       );
-      mount(VGame, {
+      mount(VGameOver, {
         attachTo: document.body,
         global: { plugins: [vuetify] },
       });
@@ -46,46 +46,12 @@ describe("VGame", () => {
     });
   });
 
-  describe("待ったボタン", () => {
-    it("allowUndo: false のとき待ったボタンが表示されない", () => {
-      const store = useGameStore();
-      store.startGame({ allowUndo: false });
-      const wrapper = mount(VGame, { global: { plugins: [vuetify] } });
-      expect(wrapper.find("[data-testid='undo-button']").exists()).toBe(false);
-    });
-
-    it("allowUndo: true のとき待ったボタンが表示される", () => {
-      const store = useGameStore();
-      store.startGame({ allowUndo: true });
-      const wrapper = mount(VGame, { global: { plugins: [vuetify] } });
-      expect(wrapper.find("[data-testid='undo-button']").exists()).toBe(true);
-    });
-
-    it("allowUndo: true かつ canUndo: false のとき待ったボタンが disabled", () => {
-      const store = useGameStore();
-      store.startGame({ allowUndo: true });
-      const wrapper = mount(VGame, { global: { plugins: [vuetify] } });
-      const btn = wrapper.find("[data-testid='undo-button']");
-      expect(btn.attributes("disabled")).toBeDefined();
-    });
-
-    it("allowUndo: true かつ canUndo: true のとき待ったボタンをクリックで undo が呼ばれる", async () => {
-      const store = useGameStore();
-      store.startGame({ allowUndo: true });
-      store.put(3, 2);
-      const wrapper = mount(VGame, { global: { plugins: [vuetify] } });
-      await wrapper.find("[data-testid='undo-button']").trigger("click");
-      expect(store.canUndo).toBe(false); // undo 後は履歴が空
-    });
-  });
-
   it("ゲームが終了して黒が勝った場合、confetti が呼ばれる", async () => {
     const store = useGameStore();
     store.board.rows.forEach((row) =>
       row.cells.forEach((cell) => (cell.state = CellState.Black)),
     );
     await nextTick();
-
     expect(mockConfetti).toHaveBeenCalledOnce();
   });
 
@@ -95,13 +61,11 @@ describe("VGame", () => {
       row.cells.forEach((cell) => (cell.state = CellState.White)),
     );
     await nextTick();
-
     expect(mockConfetti).toHaveBeenCalledOnce();
   });
 
   it("ゲームが終了していない状態では confetti が呼ばれない", async () => {
     await nextTick();
-
     expect(mockConfetti).not.toHaveBeenCalled();
   });
 
@@ -114,7 +78,6 @@ describe("VGame", () => {
       }),
     );
     await nextTick();
-
     expect(mockConfetti).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/VGameScore.spec.ts
+++ b/tests/unit/VGameScore.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import { createVuetify } from "vuetify";
+import { useGameStore } from "@/stores/game";
+import VGameScore from "@/components/reversi/VGameScore.vue";
+
+const vuetify = createVuetify();
+
+describe("VGameScore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe("待ったボタン", () => {
+    it("allowUndo: false のとき待ったボタンが表示されない", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: false });
+      const wrapper = mount(VGameScore, { global: { plugins: [vuetify] } });
+      expect(wrapper.find("[data-testid='undo-button']").exists()).toBe(false);
+    });
+
+    it("allowUndo: true のとき待ったボタンが表示される", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      const wrapper = mount(VGameScore, { global: { plugins: [vuetify] } });
+      expect(wrapper.find("[data-testid='undo-button']").exists()).toBe(true);
+    });
+
+    it("allowUndo: true かつ canUndo: false のとき待ったボタンが disabled", () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      const wrapper = mount(VGameScore, { global: { plugins: [vuetify] } });
+      expect(
+        wrapper.find("[data-testid='undo-button']").attributes("disabled"),
+      ).toBeDefined();
+    });
+
+    it("allowUndo: true かつ canUndo: true のとき待ったボタンをクリックで undo が呼ばれる", async () => {
+      const store = useGameStore();
+      store.startGame({ allowUndo: true });
+      store.put(3, 2);
+      const wrapper = mount(VGameScore, { global: { plugins: [vuetify] } });
+      await wrapper.find("[data-testid='undo-button']").trigger("click");
+      expect(store.canUndo).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## 何をしたか

`VGame.vue` に混在していたスコア表示・ゲーム終了ダイアログ・パス通知を3コンポーネントに分割した。

| 新コンポーネント | 責務 |
|----------------|------|
| `VGameScore.vue` | 手番・スコア表示・待ったボタン |
| `VGameOver.vue` | ゲーム終了ダイアログ・confetti |
| `VPassNotice.vue` | パス通知スナックバー |

ユニットテストも `VGameScore.spec.ts` / `VGameOver.spec.ts` に対応分割した。
インテグレーションテストは `VGame.spec.ts` に残し、合成動作の検証を継続している。

## なぜしたか

次の #219（a11y 対応）で各領域に `aria-live` や `role` を追加する前に構造を整理するため。
分割前に対応すると関心事が混在してレビューしにくくなる。

## テスト確認

- [x] `npm run test:unit` が通ることを確認した（67 tests passed）
- [x] `npm run test:integration` が通ることを確認した（16 tests passed）
- [x] `npm run type-check` が通ることを確認した
- [x] `npm run lint` が通ることを確認した

closes #218