### PR TITLE
feat(lint): eslint-plugin-vuejs-accessibility を追加して a11y 違反を自動検知する

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     "eslint:recommended",
     "@vue/eslint-config-typescript",
     "@vue/eslint-config-prettier",
+    "plugin:vuejs-accessibility/recommended",
   ],
   parserOptions: {
     ecmaVersion: 2020,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-vue": "^9.24.0",
+        "eslint-plugin-vuejs-accessibility": "^2.5.0",
         "jsdom": "^29.1.1",
         "knip": "^6.14.2",
         "lint-staged": "^17.0.5",
@@ -3564,6 +3565,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -4499,6 +4510,24 @@
       },
       "peerDependencies": {
         "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.5.0.tgz",
+      "integrity": "sha512-oZ2fL4tS91Cm/ezH3BueNP+FtpbbeS627OSqqgp9/lsN//glmoPcLBT6D53xwGocLtyBybaT99tX4ThBh8+ytA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.0",
+        "vue-eslint-parser": "^9.0.0 || ^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "globals": ">= 13.12.1"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-vue": "^9.24.0",
+    "eslint-plugin-vuejs-accessibility": "^2.5.0",
     "jsdom": "^29.1.1",
     "knip": "^6.14.2",
     "lint-staged": "^17.0.5",

--- a/src/components/reversi/VCell.vue
+++ b/src/components/reversi/VCell.vue
@@ -1,8 +1,8 @@
 <template>
-  <div
+  <!-- 有効な手はネイティブ button を使う。div + role="button" より意味が明確で linter も通るため -->
+  <button
+    v-if="isValid"
     class="cell-wrapper"
-    :role="cellRole"
-    :tabindex="cellTabIndex"
     :aria-label="ariaLabel"
     @click="onClick"
     @keydown.enter.prevent="onClick"
@@ -10,7 +10,19 @@
   >
     <div class="cell"></div>
     <div class="stone" :class="stoneClass"></div>
-    <div v-if="isValid" class="valid-hint"></div>
+    <div class="valid-hint"></div>
+  </button>
+  <!-- 石・空きマスはインタラクションなし -->
+  <div
+    v-else
+    class="cell-wrapper"
+    :role="props.cell.isBlack || props.cell.isWhite ? 'img' : undefined"
+    :aria-label="
+      props.cell.isBlack || props.cell.isWhite ? ariaLabel : undefined
+    "
+  >
+    <div class="cell"></div>
+    <div class="stone" :class="stoneClass"></div>
   </div>
 </template>
 
@@ -31,24 +43,12 @@ const isValid = computed(() =>
   store.validMoves.some((p) => p.x === props.cell.x && p.y === props.cell.y),
 );
 
-// 有効な手だけ button にする。石や置けないマスを button にするとキーボードユーザーが
-// Tab で 64 マス全部を通過しなければならず、目的の操作に到達できないため
-const cellRole = computed(() => {
-  if (isValid.value) return "button";
-  if (props.cell.isBlack || props.cell.isWhite) return "img";
-  return "presentation";
-});
-
-// 有効な手だけ Tab 停止にする。それ以外は tabindex="-1" でフォーカス対象から除外する
-const cellTabIndex = computed(() => (isValid.value ? 0 : -1));
-
 // 座標は 1 始まりで表記する。スクリーンリーダー向けに石の状態を自然言語で伝えるため
 const ariaLabel = computed(() => {
   const pos = `${props.cell.x + 1},${props.cell.y + 1}`;
   if (props.cell.isBlack) return `${pos} 黒の石`;
   if (props.cell.isWhite) return `${pos} 白の石`;
-  if (isValid.value) return `${pos} 置けます`;
-  return `${pos} 空き`;
+  return `${pos} 置けます`;
 });
 
 function onClick() {
@@ -59,6 +59,11 @@ function onClick() {
 <style scoped>
 .cell-wrapper {
   position: relative;
+  /* button のデフォルトスタイルをリセットする。見た目はセルと同一にするため */
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
 }
 
 .cell {

--- a/tests/unit/VCell.spec.ts
+++ b/tests/unit/VCell.spec.ts
@@ -41,31 +41,37 @@ describe("VCell", () => {
   });
 
   describe("アクセシビリティ", () => {
-    it("有効な手のマスは role='button' と tabindex='0'", () => {
+    it("有効な手のマスは <button> 要素でレンダリングされる", () => {
       const store = useGameStore();
       // (3,2) は初期盤面で黒の有効な手
       const cell = store.board.rows[2].cells[3];
       const wrapper = mount(VCell, { props: { cell } });
-      const el = wrapper.find(".cell-wrapper");
-      expect(el.attributes("role")).toBe("button");
-      expect(el.attributes("tabindex")).toBe("0");
+      expect(wrapper.find("button.cell-wrapper").exists()).toBe(true);
     });
 
-    it("黒石のセルは role='img' と tabindex='-1'", () => {
+    it("有効な手のマスの aria-label は '座標 置けます'", () => {
+      const store = useGameStore();
+      const cell = store.board.rows[2].cells[3]; // (3,2)
+      const wrapper = mount(VCell, { props: { cell } });
+      expect(wrapper.find("button.cell-wrapper").attributes("aria-label")).toBe(
+        "4,3 置けます",
+      );
+    });
+
+    it("黒石のセルは role='img' の <div> でレンダリングされる", () => {
       const cell = new Cell(0, 0);
       cell.state = CellState.Black;
       const wrapper = mount(VCell, { props: { cell } });
-      const el = wrapper.find(".cell-wrapper");
+      const el = wrapper.find("div.cell-wrapper");
       expect(el.attributes("role")).toBe("img");
-      expect(el.attributes("tabindex")).toBe("-1");
     });
 
-    it("置けない空きマスは role='presentation' と tabindex='-1'", () => {
+    it("置けない空きマスは role 属性なし・aria-label なしの <div>", () => {
       const cell = new Cell(0, 0);
       const wrapper = mount(VCell, { props: { cell } });
-      const el = wrapper.find(".cell-wrapper");
-      expect(el.attributes("role")).toBe("presentation");
-      expect(el.attributes("tabindex")).toBe("-1");
+      const el = wrapper.find("div.cell-wrapper");
+      expect(el.attributes("role")).toBeUndefined();
+      expect(el.attributes("aria-label")).toBeUndefined();
     });
 
     it("黒石のセルの aria-label は '座標 黒の石'", () => {
@@ -86,12 +92,12 @@ describe("VCell", () => {
       );
     });
 
-    it("空きセルの aria-label は '座標 空き'", () => {
+    it("空きセルは aria-label を持たない（非インタラクティブ）", () => {
       const cell = new Cell(0, 0);
       const wrapper = mount(VCell, { props: { cell } });
-      expect(wrapper.find(".cell-wrapper").attributes("aria-label")).toContain(
-        "空き",
-      );
+      expect(
+        wrapper.find(".cell-wrapper").attributes("aria-label"),
+      ).toBeUndefined();
     });
 
     it("Enter キーで put が呼ばれる", async () => {


### PR DESCRIPTION
## 何をしたか

- `eslint-plugin-vuejs-accessibility` を devDependencies に追加
- `.eslintrc.js` に `plugin:vuejs-accessibility/recommended` を追加
- 追加により発生した `no-static-element-interactions` 違反を修正
  - `VCell.vue`: div + 動的 role → 有効なマスは `<button>`、石/空きは `<div>` に分離

## なぜしたか

#219 で aria 属性・キーボード操作を追加したが、今後の開発で a11y が退行しても
lint で気づけなかった。CI の lint チェックに組み込むことで自動検知できるようにする。

## VCell.vue の変更内容

| 状態 | 変更前 | 変更後 |
|------|--------|--------|
| 有効な手 | `<div role="button">` | `<button>`（ネイティブ要素） |
| 石があるマス | `<div role="img">` | `<div role="img">`（変更なし） |
| 置けない空きマス | `<div role="presentation">` | `<div>`（role/aria-label なし） |

## テスト確認

- [x] `npm run lint` がエラーなく通ることを確認した
- [x] `npm run test:unit` が通ることを確認した（76 tests passed）
- [x] `npm run test:integration` が通ることを確認した（16 tests passed）
- [x] VCell のテストを新しい実装に合わせて更新した

closes #238