### PR TITLE
feat(a11y): @axe-core/playwright で WCAG 自動検知を E2E に追加する

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,108 @@
+name: A11y Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/e2e/a11y.spec.ts"
+      - ".github/workflows/a11y.yml"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  a11y:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npx playwright install --with-deps chromium
+      # テスト失敗時も後続のコメント投稿ステップを実行するため continue-on-error を使う
+      - name: a11y テストを実行する
+        id: a11y
+        run: npx playwright test tests/e2e/a11y.spec.ts --reporter=json
+        continue-on-error: true
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: a11y-results.json
+
+      - name: PR にコメントを投稿する
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            function icon(status) {
+              return status === 'passed' ? '✅' : '❌';
+            }
+
+            let rows = [];
+            let allPassed = true;
+
+            try {
+              const raw = JSON.parse(fs.readFileSync('a11y-results.json', 'utf8'));
+
+              function walk(suite) {
+                for (const spec of suite.specs || []) {
+                  const status = spec.tests?.[0]?.results?.[0]?.status ?? 'unknown';
+                  if (status !== 'passed') allPassed = false;
+                  rows.push({ title: spec.title, status });
+                }
+                for (const s of suite.suites || []) walk(s);
+              }
+              for (const s of raw.suites || []) walk(s);
+            } catch (e) {
+              allPassed = false;
+              rows = [{ title: 'テスト実行エラー', status: 'failed' }];
+            }
+
+            const headline = allPassed ? '✅ WCAG チェック通過' : '❌ WCAG 違反を検出';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const lines = [
+              '<!-- a11y-report -->',
+              `## A11y: ${headline}`,
+              '',
+              '| 画面 | 結果 |',
+              '|------|:----:|',
+              ...rows.map(r => `| ${r.title} | ${icon(r.status)} |`),
+            ];
+
+            if (!allPassed) {
+              lines.push('', `詳細は [CI ログ](${runUrl}) を確認してください。`);
+            }
+
+            const body = lines.join('\n');
+
+            // fork PR では token が read-only のためスキップする
+            if (context.payload.pull_request?.head?.repo?.fork) {
+              core.info('Skipping PR comment: token is read-only on fork PRs');
+              return;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body.includes('<!-- a11y-report -->'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -41,7 +41,8 @@ jobs:
             }
 
             let rows = [];
-            let allPassed = true;
+            let passedCount = 0;
+            let failedCount = 0;
 
             try {
               const raw = JSON.parse(fs.readFileSync('a11y-results.json', 'utf8'));
@@ -49,23 +50,49 @@ jobs:
               function walk(suite) {
                 for (const spec of suite.specs || []) {
                   const status = spec.tests?.[0]?.results?.[0]?.status ?? 'unknown';
-                  if (status !== 'passed') allPassed = false;
+                  if (status === 'passed') passedCount++;
+                  else failedCount++;
                   rows.push({ title: spec.title, status });
                 }
                 for (const s of suite.suites || []) walk(s);
               }
               for (const s of raw.suites || []) walk(s);
             } catch (e) {
-              allPassed = false;
+              failedCount++;
               rows = [{ title: 'テスト実行エラー', status: 'failed' }];
             }
+
+            const total = passedCount + failedCount;
+            const allPassed = failedCount === 0;
+
+            // 違反テスト数でランクを決定する
+            function getRank(violated) {
+              if (violated === 0) return { label: 'S_Rank', color: 'brightgreen', display: 'S ランク' };
+              if (violated <= 2) return { label: 'A_Rank', color: 'yellowgreen', display: 'A ランク' };
+              if (violated <= 5) return { label: 'B_Rank', color: 'yellow',      display: 'B ランク' };
+              return                    { label: 'C_Rank', color: 'red',          display: 'C ランク' };
+            }
+
+            const rank = getRank(failedCount);
+            const badgeUrl = `https://img.shields.io/badge/A11y-${rank.label}-${rank.color}?style=flat-square`;
+
+            // Mermaid 円グラフ（GitHub の issue/PR コメントでレンダリングされる）
+            const pieChart = [
+              '```mermaid',
+              `pie title WCAG チェック結果（${total} テスト）`,
+              `    "通過" : ${passedCount}`,
+              `    "違反" : ${failedCount}`,
+              '```',
+            ].join('\n');
 
             const headline = allPassed ? '✅ WCAG チェック通過' : '❌ WCAG 違反を検出';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const lines = [
               '<!-- a11y-report -->',
-              `## A11y: ${headline}`,
+              `## A11y: ${headline}　![rank](${badgeUrl})`,
+              '',
+              pieChart,
               '',
               '| 画面 | 結果 |',
               '|------|:----:|',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "vuetify": "^4.0.7"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@playwright/test": "^1.60.0",
@@ -94,6 +95,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -3654,6 +3668,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "vuetify": "^4.0.7"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@playwright/test": "^1.60.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,13 @@
     <v-app-bar color="primary">
       <v-toolbar-title>Reversi</v-toolbar-title>
       <v-spacer />
-      <v-btn icon @click="toggleTheme">
+      <v-btn
+        icon
+        :aria-label="
+          isDark ? 'ライトモードに切り替える' : 'ダークモードに切り替える'
+        "
+        @click="toggleTheme"
+      >
         <v-icon>{{
           isDark ? "mdi-weather-sunny" : "mdi-weather-night"
         }}</v-icon>

--- a/src/components/VMain.vue
+++ b/src/components/VMain.vue
@@ -1,5 +1,6 @@
 <template>
   <v-container fluid>
+    <h1 class="text-h4 text-center mb-6">リバーシ</h1>
     <div class="d-flex justify-center mb-4">
       <v-checkbox
         v-model="allowUndoEnabled"

--- a/src/components/reversi/VGameOver.vue
+++ b/src/components/reversi/VGameOver.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-dialog v-model="store.isGameOver" persistent max-width="400">
+  <v-dialog
+    v-model="store.isGameOver"
+    persistent
+    max-width="400"
+    aria-label="ゲーム終了"
+  >
     <v-card>
       <v-card-title class="text-h5 text-center pt-6">ゲーム終了</v-card-title>
       <v-card-text class="text-center text-h6">

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test.describe("a11y: WCAG 自動チェック", () => {
+  test("スタート画面に WCAG 違反がない", async ({ page }) => {
+    await page.goto("/");
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("ゲーム画面に WCAG 違反がない", async ({ page }) => {
+    await page.goto("/#/game");
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("ゲーム終了ダイアログに WCAG 違反がない", async ({ page }) => {
+    await page.goto("/#/game");
+    const cells = page.locator(".cell-wrapper");
+    for (const index of [37, 45, 44, 29, 20, 11, 19, 43, 26, 25]) {
+      await cells.nth(index).click();
+    }
+    await expect(page.getByText("ゲーム終了")).toBeVisible();
+    // canvas-confetti が body 直下に <canvas> を挿入する。
+    // サードパーティ要素のため landmark チェック（region ルール）の対象から除外する
+    const results = await new AxeBuilder({ page }).exclude("canvas").analyze();
+    expect(results.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 何をしたか

- `@axe-core/playwright` を devDependencies に追加
- `tests/e2e/a11y.spec.ts` を新規作成（スタート画面・ゲーム画面・ゲーム終了ダイアログの WCAG チェック）
- `.github/workflows/a11y.yml` を新規作成（PR 時に自動実行 → 結果をコメント投稿）
- テスト追加で検出した違反を合わせて修正

## 修正した a11y 違反

| ファイル | 違反 | 修正内容 |
|---------|------|---------|
| `App.vue` | `button-name`: テーマ切り替えボタンに名前なし | `:aria-label` を動的に設定 |
| `VMain.vue` | `page-has-heading-one`: スタート画面に h1 なし | `<h1>リバーシ</h1>` を追加 |
| `VGameOver.vue` | `aria-dialog-name`: ダイアログに名前なし | `aria-label="ゲーム終了"` を追加 |

canvas-confetti が body 直下に挿入する `<canvas>` は `.exclude("canvas")` でスキャン対象外にした（サードパーティ要素のため）。

## PR コメントの形式（A11y Check ワークフロー）

```
## A11y: ✅ WCAG チェック通過

| 画面 | 結果 |
|------|:----:|
| スタート画面に WCAG 違反がない | ✅ |
| ゲーム画面に WCAG 違反がない | ✅ |
| ゲーム終了ダイアログに WCAG 違反がない | ✅ |
```

## テスト確認

- [x] `npm run test:unit` が通ることを確認した（76 tests passed）
- [x] `npx playwright test` が通ることを確認した（16 tests passed）
- [x] `npm run lint` が通ることを確認した

closes #240
closes #243