### PR TITLE
perf(store): isGameOver で validMoves の computed 結果を再利用する

### DIFF
--- a/src/models/reversi.ts
+++ b/src/models/reversi.ts
@@ -118,17 +118,10 @@ export class Board {
     return moves;
   }
 
-  // パスのロジック：全マスを検索、ひっくり返せるマスがなければ飛ばす
+  // validMoves() を再利用する。独立した 64 マス探索を重複して書くと
+  // 「置けるか」の判定ロジックが 2 箇所に分散し、片方だけ変更したときに差異が生じるため
   public shouldPass(): boolean {
-    for (let i = 0; i < 8; i++) {
-      for (let j = 0; j < 8; j++) {
-        const reversedList = this.search(new Point(i, j));
-        if (reversedList.length > 0) {
-          return false;
-        }
-      }
-    }
-    return true;
+    return this.validMoves().length === 0;
   }
 }
 

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -16,19 +16,19 @@ export const useGameStore = defineStore("game", () => {
     board.turn === CellState.Black ? "黒の手番" : "白の手番",
   );
 
+  const validMoves = computed(() => board.validMoves());
+
   // 両者ともパスになる = どちらの手番でも置ける場所がない
+  // 現在手番は validMoves（computed 済み）を再利用し、64 マス探索の重複を避ける
   // toRaw で next() を呼ぶことで reactive なターン変更を起こさずに相手番を検査する
   const isGameOver = computed(() => {
-    const currentTurnCanPass = board.shouldPass();
-    if (!currentTurnCanPass) return false;
+    if (validMoves.value.length > 0) return false;
     const raw = toRaw(board);
     raw.next();
-    const otherTurnCanPass = board.shouldPass();
+    const otherCanMove = raw.validMoves().length > 0;
     raw.next();
-    return otherTurnCanPass;
+    return !otherCanMove;
   });
-
-  const validMoves = computed(() => board.validMoves());
 
   const winner = computed((): CellState | null => {
     if (board.blacks > board.whites) return CellState.Black;


### PR DESCRIPTION
closes #216

## 変更内容

### 問題

`shouldPass()` と `validMoves()` が同じ 64 マス × 8 方向探索を独立して実行しており、
`isGameOver` computed 内で `board.shouldPass()` を直接呼ぶことで
`validMoves` computed の計算結果が活用されていなかった。

### 修正

**`src/models/reversi.ts`**
- `shouldPass()` を `validMoves().length === 0` で表現し直し、重複ロジックを排除

**`src/stores/game.ts`**
- `validMoves` computed の宣言を `isGameOver` より前に移動
- `isGameOver` の現在手番チェックを `board.shouldPass()` → `validMoves.value.length > 0` に変更
  - memoized 済みの computed を再利用し、64 マス探索の重複計算を回避
- 相手番チェックは `raw.validMoves()` を使用（toRaw 経由でリアクティビティを回避する設計は維持）

## テスト

- `npm run test:unit`: 76 passed
- `npm run test:integration`: 16 passed
- `npm run test:e2e`: 16 passed