### PR TITLE
feat(settings): 設定ページとホバープレビュー機能を追加する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,9 @@
           isDark ? "mdi-weather-sunny" : "mdi-weather-night"
         }}</v-icon>
       </v-btn>
+      <v-btn icon aria-label="設定" @click="router.push('/settings')">
+        <v-icon>mdi-cog</v-icon>
+      </v-btn>
     </v-app-bar>
     <v-main>
       <router-view />
@@ -24,6 +27,9 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useTheme } from "vuetify";
+import { useRouter } from "vue-router";
+
+const router = useRouter();
 
 const theme = useTheme();
 const isDark = computed(() => theme.global.name.value === "dark");

--- a/src/components/VSettings.vue
+++ b/src/components/VSettings.vue
@@ -1,0 +1,27 @@
+<template>
+  <v-container>
+    <h1 class="text-h5 mb-4">設定</h1>
+    <v-list lines="two">
+      <v-list-subheader>アシスト機能</v-list-subheader>
+      <v-list-item
+        title="ホバープレビュー"
+        subtitle="置ける場所にマウスを乗せたとき、石を半透明で表示する"
+      >
+        <template #append>
+          <v-switch
+            v-model="settings.hoverPreview"
+            data-testid="hover-preview-switch"
+            color="primary"
+            hide-details
+          />
+        </template>
+      </v-list-item>
+    </v-list>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { useSettingsStore } from "@/stores/settings";
+
+const settings = useSettingsStore();
+</script>

--- a/src/components/reversi/VCell.vue
+++ b/src/components/reversi/VCell.vue
@@ -11,6 +11,11 @@
     <div class="cell"></div>
     <div class="stone" :class="stoneClass"></div>
     <div class="valid-hint"></div>
+    <div
+      v-if="settingsStore.hoverPreview"
+      class="hover-preview"
+      :class="hoverPreviewClass"
+    ></div>
   </button>
   <!-- 石・空きマスはインタラクションなし -->
   <div
@@ -28,11 +33,13 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { type Cell } from "@/models/reversi";
+import { type Cell, CellState } from "@/models/reversi";
 import { useGameStore } from "@/stores/game";
+import { useSettingsStore } from "@/stores/settings";
 
 const props = defineProps<{ cell: Cell }>();
 const store = useGameStore();
+const settingsStore = useSettingsStore();
 
 const stoneClass = computed(() => ({
   "white-stone": props.cell.isWhite,
@@ -42,6 +49,12 @@ const stoneClass = computed(() => ({
 const isValid = computed(() =>
   store.validMoves.some((p) => p.x === props.cell.x && p.y === props.cell.y),
 );
+
+// 現在手番の色でプレビュー石を表示する。手番が変われば自動で切り替わる
+const hoverPreviewClass = computed(() => ({
+  "hover-preview--black": store.board.turn === CellState.Black,
+  "hover-preview--white": store.board.turn === CellState.White,
+}));
 
 // 座標は 1 始まりで表記する。スクリーンリーダー向けに石の状態を自然言語で伝えるため
 const ariaLabel = computed(() => {
@@ -100,5 +113,37 @@ function onClick() {
   border-radius: 50%;
   background-color: rgba(255, 255, 255, 0.4);
   pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.hover-preview {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  height: 60px;
+  width: 60px;
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+}
+
+.hover-preview--black {
+  background-color: black;
+}
+
+.hover-preview--white {
+  background-color: white;
+}
+
+/* ホバー・フォーカス時にプレビュー石を表示し、ヒントドットを隠す */
+.cell-wrapper:hover .hover-preview,
+.cell-wrapper:focus-visible .hover-preview {
+  opacity: 0.5;
+}
+
+.cell-wrapper:hover .valid-hint,
+.cell-wrapper:focus-visible .valid-hint {
+  opacity: 0;
 }
 </style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,10 +1,12 @@
 import { createRouter, createWebHashHistory, RouteRecordRaw } from "vue-router";
 import VMain from "@/components/VMain.vue";
 import VGame from "@/components/reversi/VGame.vue";
+import VSettings from "@/components/VSettings.vue";
 
 const routes: Array<RouteRecordRaw> = [
   { path: "/", name: "VMain", component: VMain },
   { path: "/game", name: "VGame", component: VGame },
+  { path: "/settings", name: "VSettings", component: VSettings },
 ];
 
 export default createRouter({

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,0 +1,15 @@
+import { defineStore } from "pinia";
+import { ref, watch } from "vue";
+
+export const useSettingsStore = defineStore("settings", () => {
+  // デフォルト OFF。アシスト機能はユーザーが明示的に有効化する
+  const hoverPreview = ref(
+    localStorage.getItem("settings.hoverPreview") === "true",
+  );
+
+  watch(hoverPreview, (val) =>
+    localStorage.setItem("settings.hoverPreview", String(val)),
+  );
+
+  return { hoverPreview };
+});

--- a/tests/unit/VCell.spec.ts
+++ b/tests/unit/VCell.spec.ts
@@ -4,6 +4,7 @@ import { setActivePinia, createPinia } from "pinia";
 import VCell from "@/components/reversi/VCell.vue";
 import { Cell, CellState } from "@/models/reversi";
 import { useGameStore } from "@/stores/game";
+import { useSettingsStore } from "@/stores/settings";
 
 describe("VCell", () => {
   beforeEach(() => {
@@ -116,6 +117,37 @@ describe("VCell", () => {
       const wrapper = mount(VCell, { props: { cell } });
       await wrapper.find(".cell-wrapper").trigger("keydown.space");
       expect(store.board.blacks).not.toBe(initialBlacks);
+    });
+  });
+
+  describe("ホバープレビュー", () => {
+    it("hoverPreview OFF のとき .hover-preview は存在しない", () => {
+      const store = useGameStore();
+      const settings = useSettingsStore();
+      settings.hoverPreview = false;
+      const cell = store.board.rows[2].cells[3]; // 有効な手
+      const wrapper = mount(VCell, { props: { cell } });
+      expect(wrapper.find(".hover-preview").exists()).toBe(false);
+    });
+
+    it("hoverPreview ON のとき有効セルに .hover-preview が存在する", () => {
+      const store = useGameStore();
+      const settings = useSettingsStore();
+      settings.hoverPreview = true;
+      const cell = store.board.rows[2].cells[3]; // 有効な手
+      const wrapper = mount(VCell, { props: { cell } });
+      expect(wrapper.find(".hover-preview").exists()).toBe(true);
+    });
+
+    it("黒番のとき hover-preview--black クラスが付く", () => {
+      const store = useGameStore();
+      const settings = useSettingsStore();
+      settings.hoverPreview = true;
+      const cell = store.board.rows[2].cells[3];
+      const wrapper = mount(VCell, { props: { cell } });
+      expect(store.board.turn).toBe(CellState.Black);
+      expect(wrapper.find(".hover-preview--black").exists()).toBe(true);
+      expect(wrapper.find(".hover-preview--white").exists()).toBe(false);
     });
   });
 });

--- a/tests/unit/VSettings.spec.ts
+++ b/tests/unit/VSettings.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import VSettings from "@/components/VSettings.vue";
+import { useSettingsStore } from "@/stores/settings";
+import vuetify from "@/plugins/vuetify";
+
+describe("VSettings", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("ホバープレビュースイッチが存在する", () => {
+    const wrapper = mount(VSettings, { global: { plugins: [vuetify] } });
+    expect(wrapper.find("[data-testid='hover-preview-switch']").exists()).toBe(
+      true,
+    );
+  });
+
+  it("初期状態でホバープレビューは OFF", () => {
+    const settings = useSettingsStore();
+    expect(settings.hoverPreview).toBe(false);
+  });
+
+  it("store の hoverPreview を ON にするとスイッチに反映される", async () => {
+    const settings = useSettingsStore();
+    settings.hoverPreview = true;
+    const wrapper = mount(VSettings, { global: { plugins: [vuetify] } });
+    const input = wrapper.find(
+      "[data-testid='hover-preview-switch'] input[type='checkbox']",
+    );
+    expect((input.element as HTMLInputElement).checked).toBe(true);
+  });
+});


### PR DESCRIPTION
closes #30

## 変更内容

ホバープレビューは初心者向けアシスト機能のため、常時 ON ではなく
設定ページで明示的に有効化する方式にした。

### 新規ファイル
- `src/stores/settings.ts` — `hoverPreview` を管理する Pinia ストア（localStorage 永続化）
- `src/components/VSettings.vue` — v-switch でアシスト機能を ON/OFF する設定ページ
- `tests/unit/VSettings.spec.ts` — VSettings のユニットテスト

### 変更ファイル
- `src/router/index.ts` — `/settings` ルートを追加
- `src/App.vue` — ツールバーにギアアイコン（設定ページへのリンク）を追加
- `src/components/reversi/VCell.vue` — `hoverPreview ON` 時に半透明の石をホバー表示

## 動作確認チェックリスト

- [x] ツールバーのギアアイコンから設定ページへ遷移できる
- [x] ホバープレビュー OFF（デフォルト）→ 有効セルにマウスを乗せても石が出ない
- [x] ホバープレビュー ON → 半透明の石が表示される（黒番なら黒、白番なら白）
- [x] ページリロード後も設定が保持される
- [x] キーボード操作（Tab + focus-visible）でもプレビューが見える