### PR TITLE
fix(test): 黒石スナップショットを実際に占有済みのセルで撮り直す

### DIFF
--- a/tests/unit/snapshots/VCell.snap.spec.ts
+++ b/tests/unit/snapshots/VCell.snap.spec.ts
@@ -16,7 +16,7 @@ describe("VCell スナップショット", () => {
   });
 
   it("黒石セルの HTML が変わらない", () => {
-    const cell = new Cell(3, 2);
+    const cell = new Cell(3, 4);
     cell.state = CellState.Black;
     const wrapper = mount(VCell, { props: { cell } });
     expect(wrapper.html()).toMatchSnapshot();

--- a/tests/unit/snapshots/__snapshots__/VCell.snap.spec.ts.snap
+++ b/tests/unit/snapshots/__snapshots__/VCell.snap.spec.ts.snap
@@ -20,9 +20,9 @@ exports[`VCell スナップショット > 空きセルの HTML が変わらな�
 
 exports[`VCell スナップショット > 黒石セルの HTML が変わらない 1`] = `
 "<!-- 有効な手はネイティブ button を使う。div + role="button" より意味が明確で linter も通るため -->
-<button data-v-32e34ed9="" class="cell-wrapper" aria-label="4,3 黒の石">
+<!-- 石・空きマスはインタラクションなし -->
+<div data-v-32e34ed9="" class="cell-wrapper" role="img" aria-label="4,5 黒の石">
   <div data-v-32e34ed9="" class="cell"></div>
   <div data-v-32e34ed9="" class="stone black-stone"></div>
-  <div data-v-32e34ed9="" class="valid-hint"></div>
-</button>"
+</div>"
 `;


### PR DESCRIPTION
## 概要

Codex P2 指摘（PR #269）の対応。

VCell 黒石スナップショットのセル座標 `(3,2)` は初期ストアの `validMoves` に含まれるため、`isValid=true` と判定され「占有済みセルが有効手ボタンとして描画される」という不可能な DOM 状態をスナップショットとして記録していた。

初期ボードで実際に Black が占有している `(3,4)` に変更し、正しく `<div role="img">` として描画される状態でスナップショットを再生成した。

## 変更点

- `Cell(3, 2)` → `Cell(3, 4)`（初期ボードで実際に占有済みの黒石位置）
- スナップショット再生成：`<button>` + `valid-hint` → `<div role="img">`（非インタラクティブ）

## 確認

- [x] ユニットテスト 102/102 通過
- [x] E2E テスト 16/16 通過

closes #270