### PR TITLE
fix(test): router 統合テストで本番ルートレコードを使う

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,7 @@
 import { createRouter, createWebHashHistory, RouteRecordRaw } from "vue-router";
 import VMain from "@/components/VMain.vue";
 import VGame from "@/components/reversi/VGame.vue";
-const routes: Array<RouteRecordRaw> = [
+export const routes: Array<RouteRecordRaw> = [
   { path: "/", name: "VMain", component: VMain },
   { path: "/game", name: "VGame", component: VGame },
 ];

--- a/tests/integration/router.spec.ts
+++ b/tests/integration/router.spec.ts
@@ -6,6 +6,7 @@ import { createRouter, createMemoryHistory } from "vue-router";
 import VMain from "@/components/VMain.vue";
 import VGame from "@/components/reversi/VGame.vue";
 import { useGameStore } from "@/stores/game";
+import { routes } from "@/router/index";
 import { CellState } from "@/models/reversi";
 
 vi.mock("canvas-confetti");
@@ -15,10 +16,7 @@ const vuetify = createVuetify();
 function makeRouter() {
   return createRouter({
     history: createMemoryHistory(),
-    routes: [
-      { path: "/", component: VMain },
-      { path: "/game", component: VGame },
-    ],
+    routes,
   });
 }
 


### PR DESCRIPTION
## 概要

Codex P2 指摘（PR #268）の対応。

統合テストが独自に `routes` を定義していたため、`src/router/index.ts` のパスやコンポーネントマッピングを変更しても統合テストが通り続け、本番ルーティングの回帰を検出できない状態だった。

## 変更点

**`src/router/index.ts`**
- `routes` を named export に変更（`const` → `export const`）

**`tests/integration/router.spec.ts`**
- ローカルの `routes` 定義を削除
- `@/router/index` から `routes` を import して `makeRouter()` に渡す

## 確認

- [x] ユニットテスト 102/102 通過
- [x] 統合テスト 34/34 通過
- [x] E2E テスト 16/16 通過

closes #271