### PR TITLE
fix(test): 「挟めない」テストのボードセットアップを正しい座標に修正する

### DIFF
--- a/tests/unit/reversi/board.search.spec.ts
+++ b/tests/unit/reversi/board.search.spec.ts
@@ -16,11 +16,10 @@ describe("Board / search()", () => {
 
   it("相手石の先に自分の石がない（挟めない）場合は空配列を返す", () => {
     const board = new Board();
-    // (0,1) の下に (0,2)=White のみ（先が (0,3)=None）
-    board.rows[0].cells[1].state = CellState.None;
-    board.rows[0].cells[2].state = CellState.White;
+    // rows[p.y].cells[p.x] のため (0,2) = rows[2].cells[0]
+    board.rows[2].cells[0].state = CellState.White;
     board.turn = CellState.Black;
-    // (0,1) から下: White, None → 挟めない（先に自石なし）
+    // (0,1) から下: (0,2)=White, (0,3)=None → 先に自石なしで挟めない
     expect(board.search(new Point(0, 1))).toHaveLength(0);
   });
 


### PR DESCRIPTION
## 概要

PR #261 の Copilot 指摘（`tests/unit/reversi.spec.ts` line 116）の対応。PR #264 でのファイル分割後も未対応のまま `board.search.spec.ts` に引き継がれていた。

## 問題

`Board.ref()` は `rows[p.y].cells[p.x]` で参照するが、テストは `rows[0].cells[1]` / `rows[0].cells[2]`（= Point(1,0) / Point(2,0)）を変更していた。`Point(0,1)` の真下は `rows[2].cells[0]` であり、White が隣接していないため「隣に相手石がない」前のテストと同じ条件を再テストしていた。

## 修正

```diff
- board.rows[0].cells[1].state = CellState.None;
- board.rows[0].cells[2].state = CellState.White;
+ board.rows[2].cells[0].state = CellState.White;  // Point(0, 2) = (0,1) の真下
```

## 確認

- [x] ユニットテスト 102/102 通過
- [x] E2E テスト 16/16 通過

closes #276