### PR TITLE
feat(ui): スタート画面にノーマル/CPUモード選択UIを追加する

### DIFF
--- a/src/components/VMain.vue
+++ b/src/components/VMain.vue
@@ -3,7 +3,12 @@
     <h1 class="text-h4 text-center mb-6">リバーシ</h1>
 
     <div class="d-flex justify-center mb-4">
-      <v-btn-toggle v-model="selectedMode" mandatory data-testid="mode-toggle">
+      <v-btn-toggle
+        v-model="selectedMode"
+        mandatory
+        color="primary"
+        data-testid="mode-toggle"
+      >
         <v-btn value="normal" data-testid="mode-normal">ノーマル</v-btn>
         <v-btn value="cpu" data-testid="mode-cpu">CPU対戦</v-btn>
       </v-btn-toggle>

--- a/src/components/VMain.vue
+++ b/src/components/VMain.vue
@@ -1,6 +1,14 @@
 <template>
   <v-container fluid>
     <h1 class="text-h4 text-center mb-6">リバーシ</h1>
+
+    <div class="d-flex justify-center mb-4">
+      <v-btn-toggle v-model="selectedMode" mandatory data-testid="mode-toggle">
+        <v-btn value="normal" data-testid="mode-normal">ノーマル</v-btn>
+        <v-btn value="cpu" data-testid="mode-cpu">CPU対戦</v-btn>
+      </v-btn-toggle>
+    </div>
+
     <div class="d-flex justify-center mb-4">
       <v-checkbox
         v-model="allowUndoEnabled"
@@ -9,6 +17,7 @@
         hide-details
       />
     </div>
+
     <div class="d-flex justify-center">
       <v-btn
         color="primary"
@@ -26,13 +35,18 @@
 import { ref } from "vue";
 import { useRouter } from "vue-router";
 import { useGameStore } from "@/stores/game";
+import type { GameMode } from "@/stores/game";
 
 const router = useRouter();
 const store = useGameStore();
 const allowUndoEnabled = ref(false);
+const selectedMode = ref<GameMode>("normal");
 
 function startGame() {
-  store.startGame({ allowUndo: allowUndoEnabled.value });
+  store.startGame({
+    allowUndo: allowUndoEnabled.value,
+    gameMode: selectedMode.value,
+  });
   router.push("/game");
 }
 </script>

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -3,11 +3,13 @@ import { defineStore } from "pinia";
 import { Board, CellState, Point } from "@/models/reversi";
 
 type BoardSnapshot = { rows: { state: CellState }[][]; turn: CellState };
+export type GameMode = "normal" | "cpu";
 
 export const useGameStore = defineStore("game", () => {
   const board = reactive(new Board());
   const lastPassed = ref<CellState | null>(null);
   const allowUndo = ref(false);
+  const gameMode = ref<GameMode>("normal");
   const history = ref<BoardSnapshot[]>([]);
 
   const canUndo = computed(() => allowUndo.value && history.value.length > 0);
@@ -36,8 +38,9 @@ export const useGameStore = defineStore("game", () => {
     return null;
   });
 
-  function startGame(options: { allowUndo: boolean }) {
+  function startGame(options: { allowUndo: boolean; gameMode?: GameMode }) {
     allowUndo.value = options.allowUndo;
+    gameMode.value = options.gameMode ?? "normal";
     reset();
   }
 
@@ -109,6 +112,7 @@ export const useGameStore = defineStore("game", () => {
     winner,
     validMoves,
     allowUndo,
+    gameMode,
     canUndo,
     startGame,
     undo,

--- a/tests/integration/router.spec.ts
+++ b/tests/integration/router.spec.ts
@@ -63,7 +63,7 @@ describe("Router ナビゲーション", () => {
         .setValue(true);
       await wrapper.find("[data-testid='start-button']").trigger("click");
       await flushPromises();
-      expect(spy).toHaveBeenCalledWith({ allowUndo: true });
+      expect(spy).toHaveBeenCalledWith({ allowUndo: true, gameMode: "normal" });
     });
   });
 

--- a/tests/unit/VMain.spec.ts
+++ b/tests/unit/VMain.spec.ts
@@ -44,4 +44,25 @@ describe("VMain", () => {
     expect(store.allowUndo).toBe(false);
     expect(mockPush).toHaveBeenCalledWith("/game");
   });
+
+  it("ノーマルモードとCPUモードの選択ボタンが表示される", () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    expect(wrapper.find("[data-testid='mode-normal']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='mode-cpu']").exists()).toBe(true);
+  });
+
+  it("デフォルト（ノーマルモード）でスタートすると gameMode: normal が store に保存される", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.gameMode).toBe("normal");
+  });
+
+  it("CPUモードを選択してスタートすると gameMode: cpu が store に保存される", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.gameMode).toBe("cpu");
+  });
 });

--- a/tests/unit/gameStore/startGame.spec.ts
+++ b/tests/unit/gameStore/startGame.spec.ts
@@ -54,4 +54,22 @@ describe("useGameStore / startGame・reset", () => {
     expect(store.board.blacks).toBe(2);
     expect(store.board.whites).toBe(2);
   });
+
+  it("startGame を gameMode 省略で呼ぶと gameMode がデフォルト 'normal' になる", () => {
+    const store = useGameStore();
+    store.startGame({ allowUndo: false });
+    expect(store.gameMode).toBe("normal");
+  });
+
+  it("startGame({ gameMode: 'cpu' }) を呼ぶと gameMode が 'cpu' になる", () => {
+    const store = useGameStore();
+    store.startGame({ allowUndo: false, gameMode: "cpu" });
+    expect(store.gameMode).toBe("cpu");
+  });
+
+  it("startGame({ gameMode: 'normal' }) を呼ぶと gameMode が 'normal' になる", () => {
+    const store = useGameStore();
+    store.startGame({ allowUndo: false, gameMode: "normal" });
+    expect(store.gameMode).toBe("normal");
+  });
 });

--- a/tests/unit/snapshots/__snapshots__/VMain.snap.spec.ts.snap
+++ b/tests/unit/snapshots/__snapshots__/VMain.snap.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`VMain スナップショット > スタート画面の HTML が変わ�
 "<div class="v-container v-container--fluid v-locale--is-ltr">
   <h1 class="text-h4 text-center mb-6">リバーシ</h1>
   <div class="d-flex justify-center mb-4">
-    <div class="v-btn-group v-btn-group--horizontal v-theme--light v-btn-group--density-default v-btn-toggle" data-testid="mode-toggle"><button type="button" class="v-btn v-btn--active v-btn--flat v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-elevated" style="height: auto;" data-testid="mode-normal" value="normal"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+    <div class="v-btn-group v-btn-group--horizontal v-theme--light v-btn-group--density-default v-btn-toggle" data-testid="mode-toggle"><button type="button" class="v-btn v-btn--active v-btn--flat v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated" style="height: auto;" data-testid="mode-normal" value="normal"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
         <!----><span class="v-btn__content" data-no-activator="">ノーマル</span>
         <!---->
         <!---->

--- a/tests/unit/snapshots/__snapshots__/VMain.snap.spec.ts.snap
+++ b/tests/unit/snapshots/__snapshots__/VMain.snap.spec.ts.snap
@@ -4,14 +4,25 @@ exports[`VMain スナップショット > スタート画面の HTML が変わ�
 "<div class="v-container v-container--fluid v-locale--is-ltr">
   <h1 class="text-h4 text-center mb-6">リバーシ</h1>
   <div class="d-flex justify-center mb-4">
+    <div class="v-btn-group v-btn-group--horizontal v-theme--light v-btn-group--density-default v-btn-toggle" data-testid="mode-toggle"><button type="button" class="v-btn v-btn--active v-btn--flat v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-elevated" style="height: auto;" data-testid="mode-normal" value="normal"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+        <!----><span class="v-btn__content" data-no-activator="">ノーマル</span>
+        <!---->
+        <!---->
+      </button><button type="button" class="v-btn v-btn--flat v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-elevated" style="height: auto;" data-testid="mode-cpu" value="cpu"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+        <!----><span class="v-btn__content" data-no-activator="">CPU対戦</span>
+        <!---->
+        <!---->
+      </button></div>
+  </div>
+  <div class="d-flex justify-center mb-4">
     <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-checkbox" data-testid="allow-undo-checkbox">
       <!---->
       <div class="v-input__control">
         <div class="v-selection-control v-selection-control--density-default v-checkbox-btn">
           <div class="v-selection-control__wrapper">
             <!---->
-            <div class="v-selection-control__input"><i class="mdi-checkbox-blank-outline mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i><input id="checkbox-v-0" aria-disabled="false" aria-label="待った機能を有効にする" type="checkbox" value="true"></div>
-          </div><label class="v-label v-label--clickable" for="checkbox-v-0">
+            <div class="v-selection-control__input"><i class="mdi-checkbox-blank-outline mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i><input id="checkbox-v-2" aria-disabled="false" aria-label="待った機能を有効にする" type="checkbox" value="true"></div>
+          </div><label class="v-label v-label--clickable" for="checkbox-v-2">
             <!---->待った機能を有効にする
           </label>
         </div>


### PR DESCRIPTION
## Summary

- `v-btn-toggle` でノーマル/CPU対戦を選択できるUIをスタート画面に追加
- `game store` に `gameMode: 'normal' | 'cpu'` の state を追加
- CPU実装（#45）・ヒント機能（#93）の前提となる導線を整備

closes #279

## 設計判断

- 新規ルート（`/settings`）は作らず `VMain.vue` を拡張。1画面でモード設定→ゲーム開始を完結させるため
- `gameMode` は `startGame()` の optional 引数として追加。既存テストを壊さないため

## Test plan

- [x] ユニットテスト 108件 Green（store 3件・VMain 3件追加）
- [x] E2E テスト 16件 Green
- [x] ブラウザでデフォルト「ノーマル」選択状態・CPU対戦への切り替え・ゲーム遷移を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)