### PR TITLE
feat(ui): cpu対戦時に先手/後手を選択できる UI を追加する

### DIFF
--- a/src/components/VMain.vue
+++ b/src/components/VMain.vue
@@ -14,6 +14,18 @@
       </v-btn-toggle>
     </div>
 
+    <div v-if="selectedMode === 'cpu'" class="d-flex justify-center mb-4">
+      <v-btn-toggle
+        v-model="selectedPlayerColor"
+        mandatory
+        color="primary"
+        data-testid="player-color-toggle"
+      >
+        <v-btn value="black" data-testid="player-color-black">黒（先手）</v-btn>
+        <v-btn value="white" data-testid="player-color-white">白（後手）</v-btn>
+      </v-btn-toggle>
+    </div>
+
     <div class="d-flex justify-center mb-4">
       <v-checkbox
         v-model="allowUndoEnabled"
@@ -46,11 +58,13 @@ const router = useRouter();
 const store = useGameStore();
 const allowUndoEnabled = ref(false);
 const selectedMode = ref<GameMode>("normal");
+const selectedPlayerColor = ref<"black" | "white">("black");
 
 function startGame() {
   store.startGame({
     allowUndo: allowUndoEnabled.value,
     gameMode: selectedMode.value,
+    playerColor: selectedPlayerColor.value,
   });
   router.push("/game");
 }

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -10,6 +10,7 @@ export const useGameStore = defineStore("game", () => {
   const lastPassed = ref<CellState | null>(null);
   const allowUndo = ref(false);
   const gameMode = ref<GameMode>("normal");
+  const cpuColor = ref<CellState>(CellState.White);
   const history = ref<BoardSnapshot[]>([]);
 
   const canUndo = computed(() => allowUndo.value && history.value.length > 0);
@@ -38,9 +39,15 @@ export const useGameStore = defineStore("game", () => {
     return null;
   });
 
-  function startGame(options: { allowUndo: boolean; gameMode?: GameMode }) {
+  function startGame(options: {
+    allowUndo: boolean;
+    gameMode?: GameMode;
+    playerColor?: "black" | "white";
+  }) {
     allowUndo.value = options.allowUndo;
     gameMode.value = options.gameMode ?? "normal";
+    cpuColor.value =
+      options.playerColor === "white" ? CellState.Black : CellState.White;
     reset();
   }
 
@@ -113,6 +120,7 @@ export const useGameStore = defineStore("game", () => {
     validMoves,
     allowUndo,
     gameMode,
+    cpuColor,
     canUndo,
     startGame,
     undo,

--- a/tests/integration/router.spec.ts
+++ b/tests/integration/router.spec.ts
@@ -63,7 +63,11 @@ describe("Router ナビゲーション", () => {
         .setValue(true);
       await wrapper.find("[data-testid='start-button']").trigger("click");
       await flushPromises();
-      expect(spy).toHaveBeenCalledWith({ allowUndo: true, gameMode: "normal" });
+      expect(spy).toHaveBeenCalledWith({
+        allowUndo: true,
+        gameMode: "normal",
+        playerColor: "black",
+      });
     });
   });
 

--- a/tests/unit/VMain.spec.ts
+++ b/tests/unit/VMain.spec.ts
@@ -65,4 +65,36 @@ describe("VMain", () => {
     await wrapper.find("[data-testid='start-button']").trigger("click");
     expect(store.gameMode).toBe("cpu");
   });
+
+  it("ノーマルモードでは先手/後手トグルが表示されない", () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    expect(wrapper.find("[data-testid='player-color-toggle']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("CPU対戦モードを選択すると先手/後手トグルが表示される", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    expect(wrapper.find("[data-testid='player-color-toggle']").exists()).toBe(
+      true,
+    );
+  });
+
+  it("CPU対戦 + 黒（先手）でスタートすると store の cpuColor が White になる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.cpuColor).toBe("white");
+  });
+
+  it("CPU対戦 + 白（後手）でスタートすると store の cpuColor が Black になる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='player-color-white']").trigger("click");
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.cpuColor).toBe("black");
+  });
 });

--- a/tests/unit/gameStore/startGame.spec.ts
+++ b/tests/unit/gameStore/startGame.spec.ts
@@ -72,4 +72,30 @@ describe("useGameStore / startGame・reset", () => {
     store.startGame({ allowUndo: false, gameMode: "normal" });
     expect(store.gameMode).toBe("normal");
   });
+
+  it("startGame({ gameMode: 'cpu', playerColor: 'black' }) を呼ぶと cpuColor が White になる", () => {
+    const store = useGameStore();
+    store.startGame({
+      allowUndo: false,
+      gameMode: "cpu",
+      playerColor: "black",
+    });
+    expect(store.cpuColor).toBe(CellState.White);
+  });
+
+  it("startGame({ gameMode: 'cpu', playerColor: 'white' }) を呼ぶと cpuColor が Black になる", () => {
+    const store = useGameStore();
+    store.startGame({
+      allowUndo: false,
+      gameMode: "cpu",
+      playerColor: "white",
+    });
+    expect(store.cpuColor).toBe(CellState.Black);
+  });
+
+  it("playerColor を省略して startGame を呼ぶと cpuColor がデフォルト White になる", () => {
+    const store = useGameStore();
+    store.startGame({ allowUndo: false, gameMode: "cpu" });
+    expect(store.cpuColor).toBe(CellState.White);
+  });
 });

--- a/tests/unit/snapshots/__snapshots__/VMain.snap.spec.ts.snap
+++ b/tests/unit/snapshots/__snapshots__/VMain.snap.spec.ts.snap
@@ -14,6 +14,7 @@ exports[`VMain スナップショット > スタート画面の HTML が変わ�
         <!---->
       </button></div>
   </div>
+  <!--v-if-->
   <div class="d-flex justify-center mb-4">
     <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-checkbox" data-testid="allow-undo-checkbox">
       <!---->


### PR DESCRIPTION
closes #288

## Summary

- CPU対戦モード選択時のみ先手/後手トグルを表示（`v-if` で条件表示）
- `game.ts` に `cpuColor` ref を追加し、後続のCPU AIロジックで参照できるようにした
- `startGame` の引数に `playerColor?: "black" | "white"` を追加

## Test plan

- [ ] `npm run dev` でスタート画面を開き、ノーマルモードでは先手/後手トグルが非表示であることを確認
- [ ] CPU対戦を選択すると「黒（先手）」「白（後手）」トグルが表示されることを確認
- [ ] 黒（先手）でゲームスタート → store.cpuColor が "white" になっていることを確認
- [ ] 白（後手）でゲームスタート → store.cpuColor が "black" になっていることを確認
- [ ] 全ユニット・統合テスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)