### PR TITLE
feat(cpu): 初級cpu を実装する（ランダム手選択・自動着手）

### DIFF
--- a/src/components/VMain.vue
+++ b/src/components/VMain.vue
@@ -31,7 +31,9 @@
         v-model="allowUndoEnabled"
         label="待った機能を有効にする"
         data-testid="allow-undo-checkbox"
-        hide-details
+        :disabled="selectedMode === 'cpu'"
+        :hint="selectedMode === 'cpu' ? 'CPU対戦では利用できません' : ''"
+        hide-details="auto"
       />
     </div>
 
@@ -49,7 +51,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useGameStore } from "@/stores/game";
 import type { GameMode } from "@/stores/game";
@@ -59,6 +61,12 @@ const store = useGameStore();
 const allowUndoEnabled = ref(false);
 const selectedMode = ref<GameMode>("normal");
 const selectedPlayerColor = ref<"black" | "white">("black");
+
+// cpu モードに切り替えた瞬間に allowUndo を解除する。
+// disabled にするだけでは既存の true 値が残り startGame に渡ってしまうため
+watch(selectedMode, (mode) => {
+  if (mode === "cpu") allowUndoEnabled.value = false;
+});
 
 function startGame() {
   store.startGame({

--- a/src/components/reversi/VCell.vue
+++ b/src/components/reversi/VCell.vue
@@ -39,9 +39,15 @@ const stoneClass = computed(() => ({
   "black-stone": props.cell.isBlack,
 }));
 
-const isValid = computed(() =>
-  store.validMoves.some((p) => p.x === props.cell.x && p.y === props.cell.y),
-);
+// cpu のターン中は人間の有効手表示を消す。cpu の手番ハイライトを人間に見せると
+// 操作できると誤解させるため
+const isValid = computed(() => {
+  if (store.gameMode === "cpu" && store.board.turn === store.cpuColor)
+    return false;
+  return store.validMoves.some(
+    (p) => p.x === props.cell.x && p.y === props.cell.y,
+  );
+});
 
 // 座標は 1 始まりで表記する。スクリーンリーダー向けに石の状態を自然言語で伝えるため
 const ariaLabel = computed(() => {

--- a/src/components/reversi/VGame.vue
+++ b/src/components/reversi/VGame.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted, onUnmounted } from "vue";
 import VBoard from "@/components/reversi/VBoard.vue";
 import VGameScore from "@/components/reversi/VGameScore.vue";
 import VGameOver from "@/components/reversi/VGameOver.vue";
@@ -17,4 +18,20 @@ import VPassNotice from "@/components/reversi/VPassNotice.vue";
 import { useGameStore } from "@/stores/game";
 
 const store = useGameStore();
+
+// cpu先手（白後手選択）のとき、マウント直後はまだ人間が操作していないため
+// put() での自動着手が動かない。2秒後に初手をトリガーする
+let cpuFirstMoveTimer: ReturnType<typeof setTimeout> | null = null;
+
+onMounted(() => {
+  if (store.gameMode === "cpu" && store.board.turn === store.cpuColor) {
+    cpuFirstMoveTimer = setTimeout(() => store.triggerCpuMove(), 2000);
+  }
+});
+
+// アンマウント時にタイマーをクリアする。クリアしないと unmount 後に
+// store を変更してコンソールエラーが出るため
+onUnmounted(() => {
+  if (cpuFirstMoveTimer !== null) clearTimeout(cpuFirstMoveTimer);
+});
 </script>

--- a/src/models/cpu.ts
+++ b/src/models/cpu.ts
@@ -1,6 +1,9 @@
 import { Board, CellState, Point } from "@/models/reversi";
 
-export function selectMove(board: Board, color: CellState): Point | null {
+export function selectMoveBeginner(
+  board: Board,
+  color: CellState,
+): Point | null {
   const moves = board.validMoves();
   if (moves.length === 0) return null;
   return moves[Math.floor(Math.random() * moves.length)];

--- a/src/models/cpu.ts
+++ b/src/models/cpu.ts
@@ -1,0 +1,7 @@
+import { Board, CellState, Point } from "@/models/reversi";
+
+export function selectMove(board: Board, color: CellState): Point | null {
+  const moves = board.validMoves();
+  if (moves.length === 0) return null;
+  return moves[Math.floor(Math.random() * moves.length)];
+}

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -76,21 +76,23 @@ export const useGameStore = defineStore("game", () => {
     history.value = [];
   }
 
-  function put(x: number, y: number) {
+  function put(x: number, y: number, isCpuMove = false) {
     const p = new Point(x, y);
     const turnBefore = board.turn;
     const wasEmpty = board.ref(p).isNone;
 
     // { state: c.state } で新オブジェクトを生成する。cell 参照ごと保存すると
     // reactive な参照を共有してしまい、undo 後に現在の盤面が書き換わるため
-    const snapshot = allowUndo.value
-      ? {
-          rows: board.rows.map((row) =>
-            row.cells.map((c) => ({ state: c.state })),
-          ),
-          turn: board.turn,
-        }
-      : null;
+    // CPU の着手は人間が undo したときに一緒に巻き戻すため history に積まない
+    const snapshot =
+      allowUndo.value && !isCpuMove
+        ? {
+            rows: board.rows.map((row) =>
+              row.cells.map((c) => ({ state: c.state })),
+            ),
+            turn: board.turn,
+          }
+        : null;
 
     board.put(p);
 
@@ -117,11 +119,22 @@ export const useGameStore = defineStore("game", () => {
       !isGameOver.value &&
       board.turn === cpuColor.value
     ) {
+      // CPU の応手で人間パスの通知を上書きしないよう退避する
+      const passedBefore = lastPassed.value;
       const cpuMove = selectMove(toRaw(board), cpuColor.value);
       if (cpuMove) {
-        put(cpuMove.x, cpuMove.y);
+        put(cpuMove.x, cpuMove.y, true);
+        if (passedBefore !== null) lastPassed.value = passedBefore;
       }
     }
+  }
+
+  function triggerCpuMove() {
+    if (gameMode.value !== "cpu") return;
+    if (board.turn !== cpuColor.value) return;
+    if (isGameOver.value) return;
+    const move = selectMove(toRaw(board), cpuColor.value);
+    if (move) put(move.x, move.y, true);
   }
 
   return {
@@ -138,5 +151,6 @@ export const useGameStore = defineStore("game", () => {
     canUndo,
     startGame,
     undo,
+    triggerCpuMove,
   };
 });

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -75,8 +75,9 @@ export const useGameStore = defineStore("game", () => {
     playerColor?: "black" | "white";
     cpuLevel?: CpuLevel;
   }) {
-    allowUndo.value = options.allowUndo;
     gameMode.value = options.gameMode ?? "normal";
+    // cpu モードでは undo による巻き戻しが機能しないため強制的に無効化する
+    allowUndo.value = gameMode.value === "cpu" ? false : options.allowUndo;
     cpuColor.value =
       options.playerColor === "white" ? CellState.Black : CellState.White;
     cpuLevel.value = options.cpuLevel ?? "beginner";

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -77,6 +77,9 @@ export const useGameStore = defineStore("game", () => {
   }
 
   function put(x: number, y: number, isCpuMove = false) {
+    // cpu のターン中は人間の操作を受け付けない
+    if (!isCpuMove && gameMode.value === "cpu" && board.turn === cpuColor.value)
+      return;
     const p = new Point(x, y);
     const turnBefore = board.turn;
     const wasEmpty = board.ref(p).isNone;

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,10 +1,11 @@
 import { reactive, computed, ref, toRaw } from "vue";
 import { defineStore } from "pinia";
 import { Board, CellState, Point } from "@/models/reversi";
-import { selectMove } from "@/models/cpu";
+import { selectMoveBeginner } from "@/models/cpu";
 
 type BoardSnapshot = { rows: { state: CellState }[][]; turn: CellState };
 export type GameMode = "normal" | "cpu";
+export type CpuLevel = "beginner";
 
 export const useGameStore = defineStore("game", () => {
   const board = reactive(new Board());
@@ -12,6 +13,7 @@ export const useGameStore = defineStore("game", () => {
   const allowUndo = ref(false);
   const gameMode = ref<GameMode>("normal");
   const cpuColor = ref<CellState>(CellState.White);
+  const cpuLevel = ref<CpuLevel>("beginner");
   const history = ref<BoardSnapshot[]>([]);
 
   const canUndo = computed(() => allowUndo.value && history.value.length > 0);
@@ -40,15 +42,44 @@ export const useGameStore = defineStore("game", () => {
     return null;
   });
 
+  // レベルごとの selectMove を返す。レベルを追加するときはここにケースを追加する
+  function getCpuMoveSelector() {
+    return selectMoveBeginner;
+  }
+
+  // 全レベル共通: 500ms 待機してから CPU が着手する
+  // put() から再帰呼び出しせず fire-and-forget で呼ぶことで
+  // lastPassed の退避/復元ハックが不要になる
+  async function cpuTurn(): Promise<void> {
+    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+    if (
+      gameMode.value !== "cpu" ||
+      isGameOver.value ||
+      board.turn !== cpuColor.value
+    )
+      return;
+    const selectMove = getCpuMoveSelector();
+    const move = selectMove(toRaw(board), cpuColor.value);
+    if (move) {
+      put(move.x, move.y, true);
+      // 人間がパスになった場合、CPU がもう一度打つ（再度 0.5s 待つ）
+      if (!isGameOver.value && board.turn === cpuColor.value) {
+        void cpuTurn();
+      }
+    }
+  }
+
   function startGame(options: {
     allowUndo: boolean;
     gameMode?: GameMode;
     playerColor?: "black" | "white";
+    cpuLevel?: CpuLevel;
   }) {
     allowUndo.value = options.allowUndo;
     gameMode.value = options.gameMode ?? "normal";
     cpuColor.value =
       options.playerColor === "white" ? CellState.Black : CellState.White;
+    cpuLevel.value = options.cpuLevel ?? "beginner";
     reset();
   }
 
@@ -115,29 +146,25 @@ export const useGameStore = defineStore("game", () => {
       lastPassed.value = null;
     }
 
-    // cpu モードで人間が石を置けた後、CPU の手番なら自動着手する
+    // cpu モードで人間が石を置けた後、CPU の手番なら非同期で着手する
     if (
       gameMode.value === "cpu" &&
       stonePlaced &&
       !isGameOver.value &&
       board.turn === cpuColor.value
     ) {
-      // CPU の応手で人間パスの通知を上書きしないよう退避する
-      const passedBefore = lastPassed.value;
-      const cpuMove = selectMove(toRaw(board), cpuColor.value);
-      if (cpuMove) {
-        put(cpuMove.x, cpuMove.y, true);
-        if (passedBefore !== null) lastPassed.value = passedBefore;
-      }
+      void cpuTurn();
     }
   }
 
   function triggerCpuMove() {
-    if (gameMode.value !== "cpu") return;
-    if (board.turn !== cpuColor.value) return;
-    if (isGameOver.value) return;
-    const move = selectMove(toRaw(board), cpuColor.value);
-    if (move) put(move.x, move.y, true);
+    if (
+      gameMode.value !== "cpu" ||
+      board.turn !== cpuColor.value ||
+      isGameOver.value
+    )
+      return;
+    void cpuTurn();
   }
 
   return {
@@ -151,6 +178,7 @@ export const useGameStore = defineStore("game", () => {
     allowUndo,
     gameMode,
     cpuColor,
+    cpuLevel,
     canUndo,
     startGame,
     undo,

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,6 +1,7 @@
 import { reactive, computed, ref, toRaw } from "vue";
 import { defineStore } from "pinia";
 import { Board, CellState, Point } from "@/models/reversi";
+import { selectMove } from "@/models/cpu";
 
 type BoardSnapshot = { rows: { state: CellState }[][]; turn: CellState };
 export type GameMode = "normal" | "cpu";
@@ -107,6 +108,19 @@ export const useGameStore = defineStore("game", () => {
     // ゲームオーバー時はパス通知ではなく勝敗ダイアログのみ表示する
     if (isGameOver.value) {
       lastPassed.value = null;
+    }
+
+    // cpu モードで人間が石を置けた後、CPU の手番なら自動着手する
+    if (
+      gameMode.value === "cpu" &&
+      stonePlaced &&
+      !isGameOver.value &&
+      board.turn === cpuColor.value
+    ) {
+      const cpuMove = selectMove(toRaw(board), cpuColor.value);
+      if (cpuMove) {
+        put(cpuMove.x, cpuMove.y);
+      }
     }
   }
 

--- a/tests/unit/VMain.spec.ts
+++ b/tests/unit/VMain.spec.ts
@@ -97,4 +97,35 @@ describe("VMain", () => {
     await wrapper.find("[data-testid='start-button']").trigger("click");
     expect(store.cpuColor).toBe("black");
   });
+
+  it("CPU対戦モードを選択するとallowUndoチェックボックスがdisabledになる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    const checkbox = wrapper.find(
+      "[data-testid='allow-undo-checkbox'] input[type='checkbox']",
+    );
+    expect((checkbox.element as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it("CPU対戦モードに切り替えるとallowUndoがfalseにリセットされる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    const checkbox = wrapper.find(
+      "[data-testid='allow-undo-checkbox'] input[type='checkbox']",
+    );
+    await checkbox.setValue(true);
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.allowUndo).toBe(false);
+  });
+
+  it("ノーマルモードに戻すとallowUndoチェックボックスがenabledになる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='mode-normal']").trigger("click");
+    const checkbox = wrapper.find(
+      "[data-testid='allow-undo-checkbox'] input[type='checkbox']",
+    );
+    expect((checkbox.element as HTMLInputElement).disabled).toBe(false);
+  });
 });

--- a/tests/unit/cpu/beginner.spec.ts
+++ b/tests/unit/cpu/beginner.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { Board, CellState } from "@/models/reversi";
+import { selectMove } from "@/models/cpu";
+
+describe("初級CPU selectMove", () => {
+  it("有効手が複数あるとき、そのうちの1つを返す", () => {
+    const board = new Board();
+    const move = selectMove(board, CellState.Black);
+    expect(move).not.toBeNull();
+  });
+
+  it("返した手は必ず有効な手である", () => {
+    const board = new Board();
+    const move = selectMove(board, CellState.Black);
+    expect(board.search(move!).length).toBeGreaterThan(0);
+  });
+
+  it("有効手がないとき null を返す", () => {
+    const board = new Board();
+    board.rows.forEach((row) =>
+      row.cells.forEach((cell) => (cell.state = CellState.Black)),
+    );
+    const move = selectMove(board, CellState.White);
+    expect(move).toBeNull();
+  });
+});

--- a/tests/unit/cpu/beginner.spec.ts
+++ b/tests/unit/cpu/beginner.spec.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { Board, CellState } from "@/models/reversi";
-import { selectMove } from "@/models/cpu";
+import { selectMoveBeginner } from "@/models/cpu";
 
-describe("初級CPU selectMove", () => {
+describe("初級CPU selectMoveBeginner", () => {
   it("有効手が複数あるとき、そのうちの1つを返す", () => {
     const board = new Board();
-    const move = selectMove(board, CellState.Black);
+    const move = selectMoveBeginner(board, CellState.Black);
     expect(move).not.toBeNull();
   });
 
   it("返した手は必ず有効な手である", () => {
     const board = new Board();
-    const move = selectMove(board, CellState.Black);
+    const move = selectMoveBeginner(board, CellState.Black);
     expect(board.search(move!).length).toBeGreaterThan(0);
   });
 
@@ -20,7 +20,7 @@ describe("初級CPU selectMove", () => {
     board.rows.forEach((row) =>
       row.cells.forEach((cell) => (cell.state = CellState.Black)),
     );
-    const move = selectMove(board, CellState.White);
+    const move = selectMoveBeginner(board, CellState.White);
     expect(move).toBeNull();
   });
 });

--- a/tests/unit/gameStore/cpuMove.spec.ts
+++ b/tests/unit/gameStore/cpuMove.spec.ts
@@ -96,4 +96,16 @@ describe("useGameStore / CPU自動着手", () => {
     store.undo();
     expect(store.board.turn).toBe(CellState.Black);
   });
+
+  it("cpu のターン中に人間が put() しても盤面が変わらない", () => {
+    const store = useGameStore();
+    store.startGame({
+      allowUndo: false,
+      gameMode: "cpu",
+      playerColor: "white",
+    });
+    const blacksBefore = store.board.blacks;
+    store.put(3, 2);
+    expect(store.board.blacks).toBe(blacksBefore);
+  });
 });

--- a/tests/unit/gameStore/cpuMove.spec.ts
+++ b/tests/unit/gameStore/cpuMove.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useGameStore } from "@/stores/game";
+import { CellState } from "@/models/reversi";
+
+describe("useGameStore / CPU自動着手", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("cpu モードで put() すると人間の手の後に CPU が自動着手し石数が増える", () => {
+    const store = useGameStore();
+    store.startGame({
+      allowUndo: false,
+      gameMode: "cpu",
+      playerColor: "black",
+    });
+    const whitesBefore = store.board.whites;
+    store.put(3, 2);
+    expect(store.board.whites).toBeGreaterThan(whitesBefore);
+  });
+
+  it("CPU 着手後、手番が人間側（黒）に戻る", () => {
+    const store = useGameStore();
+    store.startGame({
+      allowUndo: false,
+      gameMode: "cpu",
+      playerColor: "black",
+    });
+    store.put(3, 2);
+    expect(store.board.turn).toBe(CellState.Black);
+  });
+
+  it("normal モードでは put() 後に手番が白のまま（CPU は自動着手しない）", () => {
+    const store = useGameStore();
+    store.startGame({ allowUndo: false, gameMode: "normal" });
+    store.put(3, 2);
+    expect(store.board.turn).toBe(CellState.White);
+  });
+
+  it("ゲームオーバー後は CPU の自動着手が実行されない", () => {
+    const store = useGameStore();
+    store.startGame({
+      allowUndo: false,
+      gameMode: "cpu",
+      playerColor: "black",
+    });
+    store.board.rows.forEach((row) =>
+      row.cells.forEach((cell) => (cell.state = CellState.Black)),
+    );
+    store.board.rows[0].cells[0].state = CellState.None;
+    store.board.rows[0].cells[1].state = CellState.White;
+    store.board.turn = CellState.Black;
+    const totalBefore = store.board.blacks + store.board.whites;
+    store.put(0, 0);
+    expect(store.isGameOver).toBe(true);
+    expect(store.board.blacks + store.board.whites).toBe(totalBefore + 1);
+  });
+});

--- a/tests/unit/gameStore/cpuMove.spec.ts
+++ b/tests/unit/gameStore/cpuMove.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useGameStore } from "@/stores/game";
 import { CellState } from "@/models/reversi";
@@ -6,21 +6,14 @@ import { CellState } from "@/models/reversi";
 describe("useGameStore / CPU自動着手", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    vi.useFakeTimers();
   });
 
-  it("cpu モードで put() すると人間の手の後に CPU が自動着手し石数が増える", () => {
-    const store = useGameStore();
-    store.startGame({
-      allowUndo: false,
-      gameMode: "cpu",
-      playerColor: "black",
-    });
-    const whitesBefore = store.board.whites;
-    store.put(3, 2);
-    expect(store.board.whites).toBeGreaterThan(whitesBefore);
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
-  it("CPU 着手後、手番が人間側（黒）に戻る", () => {
+  it("cpu モードで put() すると 0.5s 待機してから CPU が自動着手する", async () => {
     const store = useGameStore();
     store.startGame({
       allowUndo: false,
@@ -28,17 +21,34 @@ describe("useGameStore / CPU自動着手", () => {
       playerColor: "black",
     });
     store.put(3, 2);
+    // 人間が置いた直後: 白（CPU）番のまま — まだ着手していない
+    expect(store.board.turn).toBe(CellState.White);
+    await vi.runAllTimersAsync();
+    // 0.5s 後: CPU が着手して黒（人間）番に戻る
     expect(store.board.turn).toBe(CellState.Black);
   });
 
-  it("normal モードでは put() 後に手番が白のまま（CPU は自動着手しない）", () => {
+  it("CPU 着手後、手番が人間側（黒）に戻る", async () => {
+    const store = useGameStore();
+    store.startGame({
+      allowUndo: false,
+      gameMode: "cpu",
+      playerColor: "black",
+    });
+    store.put(3, 2);
+    await vi.runAllTimersAsync();
+    expect(store.board.turn).toBe(CellState.Black);
+  });
+
+  it("normal モードでは put() 後に手番が白のまま（CPU は自動着手しない）", async () => {
     const store = useGameStore();
     store.startGame({ allowUndo: false, gameMode: "normal" });
     store.put(3, 2);
+    await vi.runAllTimersAsync();
     expect(store.board.turn).toBe(CellState.White);
   });
 
-  it("ゲームオーバー後は CPU の自動着手が実行されない", () => {
+  it("ゲームオーバー後は CPU の自動着手が実行されない", async () => {
     const store = useGameStore();
     store.startGame({
       allowUndo: false,
@@ -53,11 +63,12 @@ describe("useGameStore / CPU自動着手", () => {
     store.board.turn = CellState.Black;
     const totalBefore = store.board.blacks + store.board.whites;
     store.put(0, 0);
+    await vi.runAllTimersAsync();
     expect(store.isGameOver).toBe(true);
     expect(store.board.blacks + store.board.whites).toBe(totalBefore + 1);
   });
 
-  it("triggerCpuMove() は CPU が先手のとき石を自動で置く", () => {
+  it("triggerCpuMove() は CPU が先手のとき 0.5s 後に石を自動で置く", async () => {
     const store = useGameStore();
     store.startGame({
       allowUndo: false,
@@ -66,18 +77,21 @@ describe("useGameStore / CPU自動着手", () => {
     });
     const blacksBefore = store.board.blacks;
     store.triggerCpuMove();
+    expect(store.board.blacks).toBe(blacksBefore); // まだ動いていない
+    await vi.runAllTimersAsync();
     expect(store.board.blacks).toBeGreaterThan(blacksBefore);
   });
 
-  it("triggerCpuMove() は normal モードでは何もしない", () => {
+  it("triggerCpuMove() は normal モードでは何もしない", async () => {
     const store = useGameStore();
     store.startGame({ allowUndo: false, gameMode: "normal" });
     const blacksBefore = store.board.blacks;
     store.triggerCpuMove();
+    await vi.runAllTimersAsync();
     expect(store.board.blacks).toBe(blacksBefore);
   });
 
-  it("triggerCpuMove() は人間が先手（board.turn が cpuColor と不一致）では何もしない", () => {
+  it("triggerCpuMove() は人間が先手（board.turn が cpuColor と不一致）では何もしない", async () => {
     const store = useGameStore();
     store.startGame({
       allowUndo: false,
@@ -86,18 +100,20 @@ describe("useGameStore / CPU自動着手", () => {
     });
     const blacksBefore = store.board.blacks;
     store.triggerCpuMove();
+    await vi.runAllTimersAsync();
     expect(store.board.blacks).toBe(blacksBefore);
   });
 
-  it("cpu モードで put() → undo() すると人間の手番（黒）に戻る", () => {
+  it("cpu モードで put() → undo() すると人間の手番（黒）に戻る", async () => {
     const store = useGameStore();
     store.startGame({ allowUndo: true, gameMode: "cpu", playerColor: "black" });
     store.put(3, 2);
-    store.undo();
+    store.undo(); // CPU が動く前に undo
+    await vi.runAllTimersAsync(); // CPU タイマーが発火しても盤面は戻っている
     expect(store.board.turn).toBe(CellState.Black);
   });
 
-  it("cpu のターン中に人間が put() しても盤面が変わらない", () => {
+  it("cpu のターン中に人間が put() しても盤面が変わらない", async () => {
     const store = useGameStore();
     store.startGame({
       allowUndo: false,
@@ -105,7 +121,8 @@ describe("useGameStore / CPU自動着手", () => {
       playerColor: "white",
     });
     const blacksBefore = store.board.blacks;
-    store.put(3, 2);
+    store.put(3, 2); // 黒番なのに白が押す → ガードで弾かれる
+    await vi.runAllTimersAsync();
     expect(store.board.blacks).toBe(blacksBefore);
   });
 });

--- a/tests/unit/gameStore/cpuMove.spec.ts
+++ b/tests/unit/gameStore/cpuMove.spec.ts
@@ -56,4 +56,44 @@ describe("useGameStore / CPU自動着手", () => {
     expect(store.isGameOver).toBe(true);
     expect(store.board.blacks + store.board.whites).toBe(totalBefore + 1);
   });
+
+  it("triggerCpuMove() は CPU が先手のとき石を自動で置く", () => {
+    const store = useGameStore();
+    store.startGame({
+      allowUndo: false,
+      gameMode: "cpu",
+      playerColor: "white",
+    });
+    const blacksBefore = store.board.blacks;
+    store.triggerCpuMove();
+    expect(store.board.blacks).toBeGreaterThan(blacksBefore);
+  });
+
+  it("triggerCpuMove() は normal モードでは何もしない", () => {
+    const store = useGameStore();
+    store.startGame({ allowUndo: false, gameMode: "normal" });
+    const blacksBefore = store.board.blacks;
+    store.triggerCpuMove();
+    expect(store.board.blacks).toBe(blacksBefore);
+  });
+
+  it("triggerCpuMove() は人間が先手（board.turn が cpuColor と不一致）では何もしない", () => {
+    const store = useGameStore();
+    store.startGame({
+      allowUndo: false,
+      gameMode: "cpu",
+      playerColor: "black",
+    });
+    const blacksBefore = store.board.blacks;
+    store.triggerCpuMove();
+    expect(store.board.blacks).toBe(blacksBefore);
+  });
+
+  it("cpu モードで put() → undo() すると人間の手番（黒）に戻る", () => {
+    const store = useGameStore();
+    store.startGame({ allowUndo: true, gameMode: "cpu", playerColor: "black" });
+    store.put(3, 2);
+    store.undo();
+    expect(store.board.turn).toBe(CellState.Black);
+  });
 });

--- a/tests/unit/gameStore/startGame.spec.ts
+++ b/tests/unit/gameStore/startGame.spec.ts
@@ -98,4 +98,10 @@ describe("useGameStore / startGame・reset", () => {
     store.startGame({ allowUndo: false, gameMode: "cpu" });
     expect(store.cpuColor).toBe(CellState.White);
   });
+
+  it("startGame({ allowUndo: true, gameMode: 'cpu' }) を呼んでも store.allowUndo が false になる", () => {
+    const store = useGameStore();
+    store.startGame({ allowUndo: true, gameMode: "cpu" });
+    expect(store.allowUndo).toBe(false);
+  });
 });


### PR DESCRIPTION
closes #283

## Summary

- `src/models/cpu.ts` を新規作成し `selectMove(board, color)` を実装（有効手からランダムに1手選ぶ）
- `src/stores/game.ts` の `put()` に CPU 自動着手ロジックを追加（cpu モード + 人間着手成功後 + ゲームオーバーでない場合のみ）

## Test plan

- [ ] `npm run dev` で CPU対戦モード・黒（先手）を選んでスタート
- [ ] 黒石を置いたとき、白（CPU）が自動で手を指すことを確認
- [ ] 白（後手）を選んでスタートしたとき、ゲーム開始直後に CPU（黒）が自動着手することを確認（※現時点では未対応 — ゲーム開始時の初手は別途実装が必要）
- [ ] ゲームオーバー後に CPU が動かないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)