### PR TITLE
feat(cpu): 中級cpu を実装する（貪欲法・最大反転手選択）(#284)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,11 @@ module.exports = {
   rules: {
     "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
     "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
+    // _ プレフィックスは「意図的な未使用」を示す TypeScript の慣例。
+    // 上位 CPU レベルで color を使うための統一インターフェースを維持するために必要
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { argsIgnorePattern: "^_" },
+    ],
   },
 };

--- a/src/components/VMain.vue
+++ b/src/components/VMain.vue
@@ -26,6 +26,20 @@
       </v-btn-toggle>
     </div>
 
+    <div v-if="selectedMode === 'cpu'" class="d-flex justify-center mb-4">
+      <v-btn-toggle
+        v-model="selectedCpuLevel"
+        mandatory
+        color="primary"
+        data-testid="cpu-level-toggle"
+      >
+        <v-btn value="beginner" data-testid="cpu-level-beginner">初級</v-btn>
+        <v-btn value="intermediate" data-testid="cpu-level-intermediate"
+          >中級</v-btn
+        >
+      </v-btn-toggle>
+    </div>
+
     <div class="d-flex justify-center mb-4">
       <v-checkbox
         v-model="allowUndoEnabled"
@@ -54,13 +68,14 @@
 import { ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useGameStore } from "@/stores/game";
-import type { GameMode } from "@/stores/game";
+import type { GameMode, CpuLevel } from "@/stores/game";
 
 const router = useRouter();
 const store = useGameStore();
 const allowUndoEnabled = ref(false);
 const selectedMode = ref<GameMode>("normal");
 const selectedPlayerColor = ref<"black" | "white">("black");
+const selectedCpuLevel = ref<CpuLevel>("beginner");
 
 // cpu モードに切り替えた瞬間に allowUndo を解除する。
 // disabled にするだけでは既存の true 値が残り startGame に渡ってしまうため
@@ -73,6 +88,7 @@ function startGame() {
     allowUndo: allowUndoEnabled.value,
     gameMode: selectedMode.value,
     playerColor: selectedPlayerColor.value,
+    cpuLevel: selectedCpuLevel.value,
   });
   router.push("/game");
 }

--- a/src/models/cpu.ts
+++ b/src/models/cpu.ts
@@ -1,8 +1,11 @@
-import { Board, CellState, Point } from "@/models/reversi";
+import { Board, CellState } from "@/models/reversi";
+import type { Point } from "@/models/reversi";
 
+// _color は初級・中級では未使用だが、上位レベルで色を考慮するときのために
+// 全レベルで統一インターフェースを保つ
 export function selectMoveBeginner(
   board: Board,
-  color: CellState,
+  _color: CellState,
 ): Point | null {
   const moves = board.validMoves();
   if (moves.length === 0) return null;
@@ -11,7 +14,7 @@ export function selectMoveBeginner(
 
 export function selectMoveIntermediate(
   board: Board,
-  color: CellState,
+  _color: CellState,
 ): Point | null {
   const moves = board.validMoves();
   if (moves.length === 0) return null;

--- a/src/models/cpu.ts
+++ b/src/models/cpu.ts
@@ -8,3 +8,14 @@ export function selectMoveBeginner(
   if (moves.length === 0) return null;
   return moves[Math.floor(Math.random() * moves.length)];
 }
+
+export function selectMoveIntermediate(
+  board: Board,
+  color: CellState,
+): Point | null {
+  const moves = board.validMoves();
+  if (moves.length === 0) return null;
+  return moves.reduce((best, p) =>
+    board.search(p).length > board.search(best).length ? p : best,
+  );
+}

--- a/src/models/cpu.ts
+++ b/src/models/cpu.ts
@@ -18,7 +18,10 @@ export function selectMoveIntermediate(
 ): Point | null {
   const moves = board.validMoves();
   if (moves.length === 0) return null;
-  return moves.reduce((best, p) =>
-    board.search(p).length > board.search(best).length ? p : best,
-  );
+  const scored = moves.map((p) => ({ p, flips: board.search(p).length }));
+  const maxFlips = Math.max(...scored.map(({ flips }) => flips));
+  const best = scored
+    .filter(({ flips }) => flips === maxFlips)
+    .map(({ p }) => p);
+  return best[Math.floor(Math.random() * best.length)];
 }

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,11 +1,11 @@
 import { reactive, computed, ref, toRaw } from "vue";
 import { defineStore } from "pinia";
 import { Board, CellState, Point } from "@/models/reversi";
-import { selectMoveBeginner } from "@/models/cpu";
+import { selectMoveBeginner, selectMoveIntermediate } from "@/models/cpu";
 
 type BoardSnapshot = { rows: { state: CellState }[][]; turn: CellState };
 export type GameMode = "normal" | "cpu";
-export type CpuLevel = "beginner";
+export type CpuLevel = "beginner" | "intermediate";
 
 export const useGameStore = defineStore("game", () => {
   const board = reactive(new Board());
@@ -44,6 +44,7 @@ export const useGameStore = defineStore("game", () => {
 
   // レベルごとの selectMove を返す。レベルを追加するときはここにケースを追加する
   function getCpuMoveSelector() {
+    if (cpuLevel.value === "intermediate") return selectMoveIntermediate;
     return selectMoveBeginner;
   }
 

--- a/tests/integration/router.spec.ts
+++ b/tests/integration/router.spec.ts
@@ -65,6 +65,7 @@ describe("Router ナビゲーション", () => {
       await flushPromises();
       expect(spy).toHaveBeenCalledWith({
         allowUndo: true,
+        cpuLevel: "beginner",
         gameMode: "normal",
         playerColor: "black",
       });

--- a/tests/unit/VMain/VMain.cpu.spec.ts
+++ b/tests/unit/VMain/VMain.cpu.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import { createVuetify } from "vuetify";
+import { useGameStore } from "@/stores/game";
+import VMain from "@/components/VMain.vue";
+
+const mockPush = vi.fn();
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const vuetify = createVuetify();
+
+describe("VMain / CPUモード設定", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockPush.mockClear();
+  });
+
+  it("ノーマルモードとCPUモードの選択ボタンが表示される", () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    expect(wrapper.find("[data-testid='mode-normal']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='mode-cpu']").exists()).toBe(true);
+  });
+
+  it("デフォルト（ノーマルモード）でスタートすると gameMode: normal が store に保存される", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.gameMode).toBe("normal");
+  });
+
+  it("CPUモードを選択してスタートすると gameMode: cpu が store に保存される", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.gameMode).toBe("cpu");
+  });
+
+  it("ノーマルモードでは先手/後手トグルが表示されない", () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    expect(wrapper.find("[data-testid='player-color-toggle']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("CPU対戦モードを選択すると先手/後手トグルが表示される", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    expect(wrapper.find("[data-testid='player-color-toggle']").exists()).toBe(
+      true,
+    );
+  });
+
+  it("CPU対戦 + 黒（先手）でスタートすると store の cpuColor が White になる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.cpuColor).toBe("white");
+  });
+
+  it("CPU対戦 + 白（後手）でスタートすると store の cpuColor が Black になる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='player-color-white']").trigger("click");
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.cpuColor).toBe("black");
+  });
+
+  it("CPU対戦モードを選択するとallowUndoチェックボックスがdisabledになる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    const checkbox = wrapper.find(
+      "[data-testid='allow-undo-checkbox'] input[type='checkbox']",
+    );
+    expect((checkbox.element as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it("CPU対戦モードに切り替えるとallowUndoがfalseにリセットされる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    const checkbox = wrapper.find(
+      "[data-testid='allow-undo-checkbox'] input[type='checkbox']",
+    );
+    await checkbox.setValue(true);
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.allowUndo).toBe(false);
+  });
+
+  it("ノーマルモードに戻すとallowUndoチェックボックスがenabledになる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='mode-normal']").trigger("click");
+    const checkbox = wrapper.find(
+      "[data-testid='allow-undo-checkbox'] input[type='checkbox']",
+    );
+    expect((checkbox.element as HTMLInputElement).disabled).toBe(false);
+  });
+
+  it("ノーマルモードでは難易度選択トグルが表示されない", () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    expect(wrapper.find("[data-testid='cpu-level-toggle']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("CPU対戦モードを選択すると難易度選択トグルが表示される", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    expect(wrapper.find("[data-testid='cpu-level-toggle']").exists()).toBe(
+      true,
+    );
+  });
+
+  it("難易度はデフォルトで「初級」が選択されている", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.cpuLevel).toBe("beginner");
+  });
+
+  it("「中級」を選択してスタートすると store の cpuLevel が intermediate になる", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='mode-cpu']").trigger("click");
+    await wrapper
+      .find("[data-testid='cpu-level-intermediate']")
+      .trigger("click");
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.cpuLevel).toBe("intermediate");
+  });
+});

--- a/tests/unit/VMain/VMain.start.spec.ts
+++ b/tests/unit/VMain/VMain.start.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import { createVuetify } from "vuetify";
+import { useGameStore } from "@/stores/game";
+import VMain from "@/components/VMain.vue";
+
+const mockPush = vi.fn();
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const vuetify = createVuetify();
+
+describe("VMain / スタート設定", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockPush.mockClear();
+  });
+
+  it("「待った機能を有効にする」チェックボックスが存在する", () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    expect(wrapper.find("[data-testid='allow-undo-checkbox']").exists()).toBe(
+      true,
+    );
+  });
+
+  it("チェックをONにしてスタートすると allowUndo: true で startGame が呼ばれ /game に遷移する", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    const checkbox = wrapper.find(
+      "[data-testid='allow-undo-checkbox'] input[type='checkbox']",
+    );
+    await checkbox.setValue(true);
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.allowUndo).toBe(true);
+    expect(mockPush).toHaveBeenCalledWith("/game");
+  });
+
+  it("チェックをOFFのままスタートすると allowUndo: false で startGame が呼ばれ /game に遷移する", async () => {
+    const wrapper = mount(VMain, { global: { plugins: [vuetify] } });
+    const store = useGameStore();
+    await wrapper.find("[data-testid='start-button']").trigger("click");
+    expect(store.allowUndo).toBe(false);
+    expect(mockPush).toHaveBeenCalledWith("/game");
+  });
+});

--- a/tests/unit/cpu/intermediate.spec.ts
+++ b/tests/unit/cpu/intermediate.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Board, CellState, Point } from "@/models/reversi";
+import { Board, CellState } from "@/models/reversi";
 import { selectMoveIntermediate } from "@/models/cpu";
 
 describe("中級CPU selectMoveIntermediate", () => {

--- a/tests/unit/cpu/intermediate.spec.ts
+++ b/tests/unit/cpu/intermediate.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { Board, CellState } from "@/models/reversi";
 import { selectMoveIntermediate } from "@/models/cpu";
 
@@ -27,12 +27,24 @@ describe("中級CPU selectMoveIntermediate", () => {
     expect(flips).toBe(maxFlips);
   });
 
-  it("同点の手が複数あるとき、いずれかの有効な手を返す", () => {
+  it("同点の手が複数あるとき、ランダムに1つを選ぶ", () => {
+    // 初期盤面は全有効手が1石返しで同点
     const board = new Board();
-    const move = selectMoveIntermediate(board, CellState.Black);
-    expect(move).not.toBeNull();
-    expect(
-      board.validMoves().some((p) => p.x === move!.x && p.y === move!.y),
-    ).toBe(true);
+    const allMoves = board.validMoves(); // 全候補は同点
+
+    const spy = vi.spyOn(Math, "random");
+    try {
+      // 先頭候補が選ばれること
+      spy.mockReturnValue(0);
+      const moveFirst = selectMoveIntermediate(board, CellState.Black);
+      expect(moveFirst).toEqual(allMoves[0]);
+
+      // 末尾候補が選ばれること
+      spy.mockReturnValue(1 - Number.EPSILON);
+      const moveLast = selectMoveIntermediate(board, CellState.Black);
+      expect(moveLast).toEqual(allMoves[allMoves.length - 1]);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/tests/unit/cpu/intermediate.spec.ts
+++ b/tests/unit/cpu/intermediate.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { Board, CellState, Point } from "@/models/reversi";
+import { selectMoveIntermediate } from "@/models/cpu";
+
+describe("中級CPU selectMoveIntermediate", () => {
+  it("有効手がないとき null を返す", () => {
+    const board = new Board();
+    board.rows.forEach((row) =>
+      row.cells.forEach((cell) => (cell.state = CellState.Black)),
+    );
+    const move = selectMoveIntermediate(board, CellState.White);
+    expect(move).toBeNull();
+  });
+
+  it("返した手は必ず有効な手である", () => {
+    const board = new Board();
+    const move = selectMoveIntermediate(board, CellState.Black);
+    expect(board.search(move!).length).toBeGreaterThan(0);
+  });
+
+  it("最も多くの石をひっくり返せる手を選ぶ", () => {
+    const board = new Board();
+    const move = selectMoveIntermediate(board, CellState.Black);
+    const flips = board.search(move!).length;
+    const allMoves = board.validMoves();
+    const maxFlips = Math.max(...allMoves.map((p) => board.search(p).length));
+    expect(flips).toBe(maxFlips);
+  });
+
+  it("同点の手が複数あるとき、いずれかの有効な手を返す", () => {
+    const board = new Board();
+    const move = selectMoveIntermediate(board, CellState.Black);
+    expect(move).not.toBeNull();
+    expect(
+      board.validMoves().some((p) => p.x === move!.x && p.y === move!.y),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/gameStore/startGame.spec.ts
+++ b/tests/unit/gameStore/startGame.spec.ts
@@ -104,4 +104,14 @@ describe("useGameStore / startGame・reset", () => {
     store.startGame({ allowUndo: true, gameMode: "cpu" });
     expect(store.allowUndo).toBe(false);
   });
+
+  it("startGame({ cpuLevel: 'intermediate' }) を呼ぶと store の cpuLevel が 'intermediate' になる", () => {
+    const store = useGameStore();
+    store.startGame({
+      allowUndo: false,
+      gameMode: "cpu",
+      cpuLevel: "intermediate",
+    });
+    expect(store.cpuLevel).toBe("intermediate");
+  });
 });

--- a/tests/unit/snapshots/__snapshots__/VMain.snap.spec.ts.snap
+++ b/tests/unit/snapshots/__snapshots__/VMain.snap.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`VMain スナップショット > スタート画面の HTML が変わ�
       </button></div>
   </div>
   <!--v-if-->
+  <!--v-if-->
   <div class="d-flex justify-center mb-4">
     <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-checkbox" data-testid="allow-undo-checkbox">
       <!---->


### PR DESCRIPTION
## 何をしたか

- `selectMoveIntermediate()` を追加（`board.search(p).length` が最大の手を選ぶ貪欲法）
  - 全手の反転数を `map` で1回だけ計算して `scored` 配列に保存し、最大反転数と同じ手をすべて収集してから `Math.random()` でランダムに1手を選ぶ（`reduce` → `map/filter/random`）
  - これにより `validMoves()` の列挙順に依存せず、同点時に均等ランダム選択が保証される
- `CpuLevel` 型に `"intermediate"` を追加、`getCpuMoveSelector()` にケースを追加
- スタート画面に難易度選択トグル（初級 / 中級）を追加
- `VMain.spec.ts` を責務単位に分割（`VMain/VMain.start.spec.ts` と `VMain/VMain.cpu.spec.ts`）

## なぜしたか

中級CPUを貪欲法（最大反転手選択）で実装するため。同点時は `validMoves()` の列挙順に依存せず均等ランダム選択とすることで、Issue #284 の完了条件「同数の場合はランダムで1つを選ぶ」を満たす。`board.search()` の重複呼び出しを排除して可読性・効率性も向上させた。

## テスト確認

- [x] `npm run test:unit` が通ることを確認した（153テスト全通過）
- [x] `npm run type-check` が通ることを確認した
- [x] `npm run lint` が通ることを確認した
- [x] 変更に対応するテストを追加した（`tests/unit/cpu/intermediate.spec.ts` に `vi.spyOn(Math, "random")` を使った同点ランダム選択の検証を追加。先頭候補・末尾候補の両方が選ばれることを `try-finally` で確実に復元しながら検証）

## 関連 issue