### PR TITLE
test(cpu): cpu レベルの強さを自己対戦テストで評価する仕組みを追加する (#307)

### DIFF
--- a/tests/unit/cpu/strength.spec.ts
+++ b/tests/unit/cpu/strength.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { Board, CellState } from "@/models/reversi";
-import type { Point } from "@/models/reversi";
+import { Board, CellState, Point } from "@/models/reversi";
 import { selectMoveBeginner, selectMoveIntermediate } from "@/models/cpu";
 
 type SelectFn = (board: Board, color: CellState) => Point | null;
@@ -32,7 +31,11 @@ function playGame(black: SelectFn, white: SelectFn): CellState | null {
       board.next();
       passes++;
     } else {
+      const stonesBefore = board.blacks + board.whites;
       board.put(move);
+      if (board.blacks + board.whites === stonesBefore) {
+        throw new Error(`CPU が無効手を返した: (${move.x}, ${move.y})`);
+      }
       passes = 0;
     }
   }
@@ -70,6 +73,15 @@ describe("CPU 強さ評価（自己対戦テスト）", () => {
     vi.restoreAllMocks();
   });
 
+  it("playGame は CPU が無効手を返したときエラーをスローする", () => {
+    // Point(0,0) は初期盤面で search が空配列を返す無効手。
+    // board.put() が no-op になり passes がリセットされ続けると無限ループになるため
+    const badCpu: SelectFn = () => new Point(0, 0);
+    expect(() => playGame(badCpu, selectMoveBeginner)).toThrow(
+      "CPU が無効手を返した",
+    );
+  }, 1000);
+
   it("中級 CPU は初級 CPU に 400 戦中 55% 以上勝つ", () => {
     const winRate = measureWinRate(
       selectMoveIntermediate,
@@ -77,5 +89,5 @@ describe("CPU 強さ評価（自己対戦テスト）", () => {
       200,
     );
     expect(winRate).toBeGreaterThan(0.55);
-  });
+  }, 10_000);
 });

--- a/tests/unit/cpu/strength.spec.ts
+++ b/tests/unit/cpu/strength.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { Board, CellState } from "@/models/reversi";
+import type { Point } from "@/models/reversi";
+import { selectMoveBeginner, selectMoveIntermediate } from "@/models/cpu";
+
+type SelectFn = (board: Board, color: CellState) => Point | null;
+
+// 2 つの CPU 関数で 1 ゲームを完全シミュレートして勝者を返す
+// board.put() は「次の手番がパスになるケース」を内部で自動処理するため、
+// このループでは「現在の手番が着手できない（CPU が null を返す）」場合のみ
+// 手動でターンを切り替えて passes をカウントする
+function playGame(black: SelectFn, white: SelectFn): CellState | null {
+  const board = new Board();
+  let passes = 0;
+
+  while (passes < 2) {
+    const player = board.turn === CellState.Black ? black : white;
+    const move = player(board, board.turn);
+    if (move === null) {
+      board.next();
+      passes++;
+    } else {
+      board.put(move);
+      passes = 0;
+    }
+  }
+
+  if (board.blacks > board.whites) return CellState.Black;
+  if (board.whites > board.blacks) return CellState.White;
+  return null;
+}
+
+// stronger を先手・後手の両方で games 回ずつ対戦させて勝率を返す
+// 先手有利・後手不利のバイアスを相殺するため両方向で測定する
+function measureWinRate(
+  stronger: SelectFn,
+  weaker: SelectFn,
+  games: number,
+): number {
+  let wins = 0;
+  for (let i = 0; i < games; i++) {
+    if (playGame(stronger, weaker) === CellState.Black) wins++;
+  }
+  for (let i = 0; i < games; i++) {
+    if (playGame(weaker, stronger) === CellState.White) wins++;
+  }
+  return wins / (games * 2);
+}
+
+describe("CPU 強さ評価（自己対戦テスト）", () => {
+  // 200 戦 × 2 方向 = 400 戦で測定。
+  // 貪欲法の実測勝率は約 60〜62%。閾値 0.55 は統計的に安定して超える値
+  it("中級 CPU は初級 CPU に 400 戦中 55% 以上勝つ", () => {
+    const winRate = measureWinRate(
+      selectMoveIntermediate,
+      selectMoveBeginner,
+      200,
+    );
+    expect(winRate).toBeGreaterThan(0.55);
+  });
+});

--- a/tests/unit/cpu/strength.spec.ts
+++ b/tests/unit/cpu/strength.spec.ts
@@ -1,9 +1,21 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Board, CellState } from "@/models/reversi";
 import type { Point } from "@/models/reversi";
 import { selectMoveBeginner, selectMoveIntermediate } from "@/models/cpu";
 
 type SelectFn = (board: Board, color: CellState) => Point | null;
+
+// 32-bit seed から決定論的な乱数列を生成する軽量 PRNG。
+// テスト中の Math.random を差し替えることで結果を再現可能にするために使う
+function mulberry32(seed: number): () => number {
+  return () => {
+    seed += 0x6d2b79f5;
+    let t = seed;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
 
 // 2 つの CPU 関数で 1 ゲームを完全シミュレートして勝者を返す
 // board.put() は「次の手番がパスになるケース」を内部で自動処理するため、
@@ -48,8 +60,16 @@ function measureWinRate(
 }
 
 describe("CPU 強さ評価（自己対戦テスト）", () => {
-  // 200 戦 × 2 方向 = 400 戦で測定。
-  // 貪欲法の実測勝率は約 60〜62%。閾値 0.55 は統計的に安定して超える値
+  beforeEach(() => {
+    // seed=42 で固定して毎回同じゲーム展開にする。
+    // Math.random をそのまま使うと統計的ばらつきで稀に閾値を下回り flaky になるため
+    vi.spyOn(Math, "random").mockImplementation(mulberry32(42));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("中級 CPU は初級 CPU に 400 戦中 55% 以上勝つ", () => {
     const winRate = measureWinRate(
       selectMoveIntermediate,


### PR DESCRIPTION
## Summary

- `playGame(black, white)` — 2 つの CPU 関数で 1 ゲームを完全シミュレート
- `measureWinRate(stronger, weaker, games)` — 先手・後手両方で N 戦させて勝率を返す
- seeded PRNG（mulberry32）で `Math.random` を差し替え、結果を決定論的にして flakiness をゼロにする
- 中級 CPU が初級 CPU に 400 戦中 55% 以上勝つことをテストで担保
- CPU が無効手を返したとき即エラーをスローして無限ループを防止
- 将来レベル追加時は `measureWinRate(新, 前, 200) > 0.55` の 1 行追加で対応可能

## 経緯

PR #308 は `feat/284-intermediate-cpu` をベースに作成したが、
#306 マージ時にそのブランチが削除されて自動 close された。
本 PR はブランチを main ベースに rebase したうえで再作成したもの。

## Test plan

- [ ] `npm run test:unit tests/unit/cpu/strength.spec.ts` 全通過
- [ ] 5 回連続実行して毎回同じ結果になることを確認

closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)