### PR TITLE
fix(cpu): playGame が合法手があるのに null をパスとして扱う問題を修正する

### DIFF
--- a/tests/unit/cpu/strength.spec.ts
+++ b/tests/unit/cpu/strength.spec.ts
@@ -28,6 +28,13 @@ function playGame(black: SelectFn, white: SelectFn): CellState | null {
     const player = board.turn === CellState.Black ? black : white;
     const move = player(board, board.turn);
     if (move === null) {
+      // 合法手があるのに null を返すのは CPU のバグ。不正なゲームを進めると
+      // 強さ測定が誤った値になるため、ここで即エラーにする
+      if (board.validMoves().length > 0) {
+        throw new Error(
+          `CPU が合法手があるのに null を返した（合法手数: ${board.validMoves().length}）`,
+        );
+      }
       board.next();
       passes++;
     } else {
@@ -79,6 +86,15 @@ describe("CPU 強さ評価（自己対戦テスト）", () => {
     const badCpu: SelectFn = () => new Point(0, 0);
     expect(() => playGame(badCpu, selectMoveBeginner)).toThrow(
       "CPU が無効手を返した",
+    );
+  }, 1000);
+
+  it("playGame は合法手があるのに null を返した CPU に対してエラーをスローする", () => {
+    // 合法手があるのに null を返す CPU はバグ。不正パスとして進めると
+    // 強さ測定が誤った値になるため即エラーにする
+    const nullCpu: SelectFn = () => null;
+    expect(() => playGame(nullCpu, selectMoveBeginner)).toThrow(
+      "CPU が合法手があるのに null を返した",
     );
   }, 1000);
 


### PR DESCRIPTION
## Summary

- PR #316 の Codex P2 指摘（`tests/unit/cpu/strength.spec.ts:32`）を修正
- CPU が `null` を返したとき、`board.validMoves()` が空でない場合はエラーをスローするように変更
- 新しいテストケースを追加：「合法手があるのに null を返した CPU に対してエラーをスローする」

## 問題

CPU にバグがあり合法手があるのに `null` を返した場合、不正なゲームが進行して強さ測定が誤った値になるリスクがあった。

## 修正

`null` を返した CPU に対して合法手チェックを追加し、合法手が残っている場合はエラーをスローする。

closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)