### PR TITLE
test(cpu): 価値の低い CPU 自己対戦テストを削除する

### DIFF
--- a/tests/unit/cpu/strength.spec.ts
+++ b/tests/unit/cpu/strength.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Board, CellState, Point } from "@/models/reversi";
-import { selectMoveBeginner, selectMoveIntermediate } from "@/models/cpu";
+import { selectMoveBeginner } from "@/models/cpu";
 
 type SelectFn = (board: Board, color: CellState) => Point | null;
 
@@ -52,23 +52,6 @@ function playGame(black: SelectFn, white: SelectFn): CellState | null {
   return null;
 }
 
-// stronger を先手・後手の両方で games 回ずつ対戦させて勝率を返す
-// 先手有利・後手不利のバイアスを相殺するため両方向で測定する
-function measureWinRate(
-  stronger: SelectFn,
-  weaker: SelectFn,
-  games: number,
-): number {
-  let wins = 0;
-  for (let i = 0; i < games; i++) {
-    if (playGame(stronger, weaker) === CellState.Black) wins++;
-  }
-  for (let i = 0; i < games; i++) {
-    if (playGame(weaker, stronger) === CellState.White) wins++;
-  }
-  return wins / (games * 2);
-}
-
 describe("CPU 強さ評価（自己対戦テスト）", () => {
   beforeEach(() => {
     // seed=42 で固定して毎回同じゲーム展開にする。
@@ -97,13 +80,4 @@ describe("CPU 強さ評価（自己対戦テスト）", () => {
       "CPU が合法手があるのに null を返した",
     );
   }, 1000);
-
-  it("中級 CPU は初級 CPU に 400 戦中 55% 以上勝つ", () => {
-    const winRate = measureWinRate(
-      selectMoveIntermediate,
-      selectMoveBeginner,
-      200,
-    );
-    expect(winRate).toBeGreaterThan(0.55);
-  }, 10_000);
 });


### PR DESCRIPTION
## 概要

`tests/unit/cpu/strength.spec.ts` の自己対戦勝率テスト（400 ゲームの完全シミュレーション）を削除する。

## 背景・理由

- 400 ゲームのシミュレーションで CPU ユニットスイートがタイムアウト（約34秒）していた（codex 指摘）
- 貪欲法（最多フリップ）がランダムに勝ち越すのはアルゴリズムの定義から自明で検証命題に乏しい
- `> 0.55` の閾値に理論的・仕様的根拠がなく、実装変更で flaky になりやすい
- seed 固定で決定論化しており、統計的性質ではなく1点観測（スナップショット）にすぎない

## 変更内容

- 自己対戦勝率テストと `measureWinRate` 関数を削除
- 未使用になった `selectMoveIntermediate` の import を削除
- `playGame` の不正系ガードテスト（無効手・null スロー）は有用なため残置

## 確認

- ✅ `npm run test:unit -- tests/unit/cpu/ --run`（9件パス・約34秒 → 653ms）
- ✅ `npm run type-check`

closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)