### PR TITLE
fix(board): 狭幅画面（iPhone SE 3rd）で盤面がはみ出さないようレスポンシブ化する

### DIFF
--- a/src/components/reversi/VBoard.vue
+++ b/src/components/reversi/VBoard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="board">
     <VRow v-for="row in board.rows" :key="row.num" :row="row" />
   </div>
 </template>
@@ -10,3 +10,12 @@ import { type Board } from "@/models/reversi";
 
 defineProps<{ board: Board }>();
 </script>
+
+<style scoped>
+/* 親幅まで縮むが 8 セル分(64px×8)を上限に保つ。狭幅画面でのはみ出しを防ぎ、
+   デスクトップでは従来の固定サイズと同じ見た目を維持するため */
+.board {
+  width: 100%;
+  max-width: 512px;
+}
+</style>

--- a/src/components/reversi/VCell.vue
+++ b/src/components/reversi/VCell.vue
@@ -86,8 +86,9 @@ function onClick() {
 
 .stone {
   position: absolute;
-  /* 旧 2px/64px ≒ 3% を比率で表現し、セルサイズに追従させる */
-  inset: 3%;
+  /* 旧 2px/64px ≒ 3% を比率で表現しつつ、下限を border 幅(2px)に揃える。
+     狭幅でセルが縮んでも石が枠線に被らないようにするため */
+  inset: max(2px, 3%);
   border-radius: 50%;
 }
 

--- a/src/components/reversi/VCell.vue
+++ b/src/components/reversi/VCell.vue
@@ -65,6 +65,9 @@ function onClick() {
 <style scoped>
 .cell-wrapper {
   position: relative;
+  /* 行内で 8 等分し正方形を保つ。固定 px だと狭幅画面で盤がはみ出すため */
+  flex: 1 1 0;
+  aspect-ratio: 1;
   /* button のデフォルトスタイルをリセットする。見た目はセルと同一にするため */
   padding: 0;
   border: none;
@@ -73,18 +76,18 @@ function onClick() {
 }
 
 .cell {
-  height: 64px;
-  width: 64px;
+  height: 100%;
+  width: 100%;
+  /* border をセル幅の内側に収める。relative なセル幅計算とずれないため */
+  box-sizing: border-box;
   background-color: darkgreen;
   border: 2px solid black;
 }
 
 .stone {
   position: absolute;
-  top: 2px;
-  left: 2px;
-  height: 60px;
-  width: 60px;
+  /* 旧 2px/64px ≒ 3% を比率で表現し、セルサイズに追従させる */
+  inset: 3%;
   border-radius: 50%;
 }
 
@@ -101,8 +104,9 @@ function onClick() {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  height: 11px;
-  width: 11px;
+  /* 旧 11px/64px ≒ 17% を比率で表現する */
+  width: 17%;
+  aspect-ratio: 1;
   border-radius: 50%;
   background-color: rgba(255, 255, 255, 0.4);
   pointer-events: none;

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+// iPhone SE 3rd 世代の CSS ビューポート（論理ピクセル）
+const IPHONE_SE_3RD = { width: 375, height: 667 };
+
+test.describe("狭幅画面（iPhone SE 3rd）でのレスポンシブ", () => {
+  test.use({ viewport: IPHONE_SE_3RD });
+
+  test("スタート画面で横スクロールが発生しない", async ({ page }) => {
+    await page.goto("/#/");
+    const overflowX = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth,
+    );
+    // サブピクセル丸め分の 1px は許容する
+    expect(overflowX).toBeLessThanOrEqual(1);
+  });
+
+  test("ゲーム画面で盤面がビューポート幅に収まる", async ({ page }) => {
+    await page.goto("/#/game");
+
+    const overflowX = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth,
+    );
+    expect(overflowX).toBeLessThanOrEqual(1);
+
+    // 盤面そのものがビューポート幅以内に収まること
+    const board = page.locator(".board");
+    const box = await board.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeLessThanOrEqual(IPHONE_SE_3RD.width);
+  });
+
+  test("セルが正方形を保つ", async ({ page }) => {
+    await page.goto("/#/game");
+    const firstCell = page.locator(".cell-wrapper").first();
+    const box = await firstCell.boundingBox();
+    expect(box).not.toBeNull();
+    // aspect-ratio: 1 により縦横がほぼ等しい（丸め 1px 許容）
+    expect(Math.abs(box!.width - box!.height)).toBeLessThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## 概要

iPhone SE 3rd（ビューポート幅 375px）など狭幅画面で盤面が横にはみ出してレスポンシブにならない問題を修正する。

## 原因

`VCell.vue` のセルが 64px 固定で、8 列ぶん（≒544px）が 375px の画面幅を超えていた。

## 変更内容

- `VCell`: セルを `flex: 1` + `aspect-ratio: 1` に、石・ヒントを比率指定（`inset`/`%`）へ変更
- `VBoard`: 盤コンテナに `width: 100%; max-width: 512px` を付与し親幅まで縮むように
- デスクトップ表示は従来通り（最大 512px = 64px×8）を維持
- iPhone SE 3rd 幅での横スクロール無し・盤の収まり・セルの正方形を検証する E2E テストを追加

## 確認

- ✅ type-check / lint / unit+snapshot / build
- ✅ 追加した E2E（responsive.spec.ts）3 件パス（375×667 で横はみ出しゼロを確認）
- ✅ VCell スナップショットは CSS のみ変更のため不変

closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)