### PR TITLE
refactor(reversi): search() の方向探索を整理し const self ハックを除去する

### DIFF
--- a/src/models/reversi.ts
+++ b/src/models/reversi.ts
@@ -52,41 +52,33 @@ export class Board {
   public search(p: Point): Point[] {
     if (!this.ref(p).isNone) return [];
 
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const self = this;
-    /**
-     * @param _p  :探索対象の座標
-     * @param next:次の座標を受け取る関数
-     * @param lst :リスト
-     */
-    const _search = (
-      _p: Point,
-      next: (pre: Point) => Point,
-      lst: Point[],
-    ): Point[] => {
-      const _next = next(_p);
-
-      if (!_next.inBoard || self.ref(_next).isNone) {
-        return [];
+    // アロー関数なので this は search() の this（＝Board）を束縛する。
+    // 通常関数だと this がずれるため self へ退避する必要があったが、不要
+    const searchDirection = (dx: number, dy: number): Point[] => {
+      const found: Point[] = [];
+      let cur = new Point(p.x + dx, p.y + dy);
+      // 相手石が続く限り集め、自分の石で閉じれば確定。
+      // 盤外・空マスに当たったら挟めないので空配列
+      while (cur.inBoard && !this.ref(cur).isNone) {
+        if (this.ref(cur).state === this.turn) return found;
+        found.push(cur);
+        cur = new Point(cur.x + dx, cur.y + dy);
       }
-      if (self.ref(_next).state !== self.turn) {
-        lst.push(_next);
-        return _search(_next, next, lst);
-      }
-      return lst;
+      return [];
     };
-    let result: Point[] = [];
 
-    // 石を置いたマスの周囲を探索
-    result = result.concat(_search(p, (p) => new Point(p.x, p.y + 1), []));
-    result = result.concat(_search(p, (p) => new Point(p.x, p.y - 1), []));
-    result = result.concat(_search(p, (p) => new Point(p.x + 1, p.y), []));
-    result = result.concat(_search(p, (p) => new Point(p.x - 1, p.y), []));
-    result = result.concat(_search(p, (p) => new Point(p.x + 1, p.y + 1), []));
-    result = result.concat(_search(p, (p) => new Point(p.x - 1, p.y + 1), []));
-    result = result.concat(_search(p, (p) => new Point(p.x + 1, p.y - 1), []));
-    result = result.concat(_search(p, (p) => new Point(p.x - 1, p.y - 1), []));
-    return result;
+    // 8方向の単位ベクトル（上下左右＋斜め4つ）
+    const directions = [
+      [0, 1],
+      [0, -1],
+      [1, 0],
+      [-1, 0],
+      [1, 1],
+      [-1, 1],
+      [1, -1],
+      [-1, -1],
+    ];
+    return directions.flatMap(([dx, dy]) => searchDirection(dx, dy));
   }
 
   public get blacks(): number {

--- a/src/models/reversi.ts
+++ b/src/models/reversi.ts
@@ -59,8 +59,10 @@ export class Board {
       let cur = new Point(p.x + dx, p.y + dy);
       // 相手石が続く限り集め、自分の石で閉じれば確定。
       // 盤外・空マスに当たったら挟めないので空配列
-      while (cur.inBoard && !this.ref(cur).isNone) {
-        if (this.ref(cur).state === this.turn) return found;
+      while (cur.inBoard) {
+        const cell = this.ref(cur);
+        if (cell.isNone) return [];
+        if (cell.state === this.turn) return found;
         found.push(cur);
         cur = new Point(cur.x + dx, cur.y + dy);
       }

--- a/tests/unit/reversi/board.search.spec.ts
+++ b/tests/unit/reversi/board.search.spec.ts
@@ -123,4 +123,35 @@ describe("Board / search()", () => {
     const result = board.search(new Point(3, 2));
     expect(result).toEqual([expect.objectContaining({ x: 3, y: 3 })]);
   });
+
+  it("8方向すべてに挟める盤面では、各方向の相手石8つを返す", () => {
+    const board = new Board();
+    board.rows.forEach((row) =>
+      row.cells.forEach((cell) => (cell.state = CellState.None)),
+    );
+    // 中心 (4,4) を空にし、8方向それぞれ距離1に白・距離2に黒を置く。
+    // 黒番で (4,4) に置くと全方向で1つずつ挟め、白8つが返るはず
+    const dirs = [
+      [0, -1],
+      [0, 1],
+      [-1, 0],
+      [1, 0],
+      [-1, -1],
+      [1, -1],
+      [-1, 1],
+      [1, 1],
+    ];
+    for (const [dx, dy] of dirs) {
+      board.rows[4 + dy].cells[4 + dx].state = CellState.White;
+      board.rows[4 + dy * 2].cells[4 + dx * 2].state = CellState.Black;
+    }
+    board.turn = CellState.Black;
+    const result = board.search(new Point(4, 4));
+    expect(result).toHaveLength(8);
+    for (const [dx, dy] of dirs) {
+      expect(result).toContainEqual(
+        expect.objectContaining({ x: 4 + dx, y: 4 + dy }),
+      );
+    }
+  });
 });


### PR DESCRIPTION
## 概要

issue #310。`Board.search()` の散らかりを、振る舞いを変えずに整理する。

## 変更内容
- 8 方向ぶんのほぼ同じ探索行（`result.concat(...)` ×8）を、単位ベクトル配列 + `flatMap` のループに集約
- 内部ヘルパはアロー関数で `this` が束縛されるため、`const self = this` を除去し `this` を直接使用
- 上記に伴い `eslint-disable @typescript-eslint/no-this-alias` を削除
- 再帰探索を素直な while ループへ整理（1 方向の探索ロジック）

## 安全性
- 純粋なリファクタで振る舞いは不変
- 8 方向すべてに挟める盤面で 8 マス返すことを固定する characterization テストを追加
- 既存の search/boundary テスト網と合わせて全 159 テスト green、lint / type-check / build OK

closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)