### PR TITLE
refactor(game): isGameOver の toRaw ミューテーションを純粋クエリに置き換える

### DIFF
--- a/src/models/reversi.ts
+++ b/src/models/reversi.ts
@@ -50,10 +50,15 @@ export class Board {
 
   // 隣の石がひっくり返せるか探索
   public search(p: Point): Point[] {
+    return this.searchFor(p, this.turn);
+  }
+
+  // 指定色の視点で p に置いたとき挟める相手石を返す純粋クエリ。
+  // turn を変更せずに相手番を検査できるよう、手番依存を color 引数に切り出した
+  public searchFor(p: Point, color: CellState): Point[] {
     if (!this.ref(p).isNone) return [];
 
-    // アロー関数なので this は search() の this（＝Board）を束縛する。
-    // 通常関数だと this がずれるため self へ退避する必要があったが、不要
+    // アロー関数なので this は searchFor() の this（＝Board）を束縛する
     const searchDirection = (dx: number, dy: number): Point[] => {
       const found: Point[] = [];
       let cur = new Point(p.x + dx, p.y + dy);
@@ -62,7 +67,7 @@ export class Board {
       while (cur.inBoard) {
         const cell = this.ref(cur);
         if (cell.isNone) return [];
-        if (cell.state === this.turn) return found;
+        if (cell.state === color) return found;
         found.push(cur);
         cur = new Point(cur.x + dx, cur.y + dy);
       }
@@ -100,10 +105,15 @@ export class Board {
   }
 
   public validMoves(): Point[] {
+    return this.validMovesFor(this.turn);
+  }
+
+  // 指定色の合法手を返す純粋クエリ。turn を変更せずに相手番を問い合わせるため
+  public validMovesFor(color: CellState): Point[] {
     const moves: Point[] = [];
     for (let y = 0; y < 8; y++) {
       for (let x = 0; x < 8; x++) {
-        if (this.search(new Point(x, y)).length > 0) {
+        if (this.searchFor(new Point(x, y), color).length > 0) {
           moves.push(new Point(x, y));
         }
       }

--- a/src/models/reversi.ts
+++ b/src/models/reversi.ts
@@ -49,6 +49,9 @@ export class Board {
   }
 
   // 隣の石がひっくり返せるか探索
+  // searchFor に統一せず薄いラッパーを残す。put・CPU・テストなど 27 箇所が
+  // search(p) を呼んでおり、「今の手番」での探索が大多数。色指定を省ける窓口を
+  // 残すことで既存呼び出しを変更せずに済み、呼び出し側の意図も簡潔になるため
   public search(p: Point): Point[] {
     return this.searchFor(p, this.turn);
   }

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -28,16 +28,14 @@ export const useGameStore = defineStore("game", () => {
 
   const validMoves = computed(() => board.validMoves());
 
-  // 両者ともパスになる = どちらの手番でも置ける場所がない
-  // 現在手番は validMoves（computed 済み）を再利用し、64 マス探索の重複を避ける
-  // toRaw で next() を呼ぶことで reactive なターン変更を起こさずに相手番を検査する
+  // 両者ともパスになる = どちらの手番でも置ける場所がない。
+  // 現在手番は validMoves（computed 済み）を再利用し、64 マス探索の重複を避ける。
+  // 相手番は turn を変えずに validMovesFor で問い合わせる（破壊的な next() の往復が不要）
   const isGameOver = computed(() => {
     if (validMoves.value.length > 0) return false;
-    const raw = toRaw(board);
-    raw.next();
-    const otherCanMove = raw.validMoves().length > 0;
-    raw.next();
-    return !otherCanMove;
+    const opponent =
+      board.turn === CellState.Black ? CellState.White : CellState.Black;
+    return board.validMovesFor(opponent).length === 0;
   });
 
   const winner = computed((): CellState | null => {

--- a/tests/unit/reversi/board.validMoves.spec.ts
+++ b/tests/unit/reversi/board.validMoves.spec.ts
@@ -20,4 +20,19 @@ describe("Board / validMoves()", () => {
     );
     expect(board.validMoves()).toHaveLength(0);
   });
+
+  it("validMovesFor(color) は手番に関係なくその色の合法手を返し、turn を変えない", () => {
+    // 期待値: 手番を白にしたときの合法手
+    const ref = new Board();
+    ref.turn = CellState.White;
+    const expectedWhite = ref.validMoves();
+
+    // 手番は黒のまま White を問い合わせる
+    const board = new Board(); // turn = Black
+    const result = board.validMovesFor(CellState.White);
+
+    expect(result).toEqual(expectedWhite);
+    // 純粋クエリ: 問い合わせで手番が変わらない
+    expect(board.turn).toBe(CellState.Black);
+  });
 });


### PR DESCRIPTION
## 概要

issue #311。`isGameOver` の `toRaw` + `next()` による破壊的ミューテーション（手番の一時変更・復元）を排除し、Board の純粋クエリに置き換える。

## 変更内容
- `Board.searchFor(p, color)` / `Board.validMovesFor(color)` を追加（`turn` を変更しない純粋クエリ）
- 既存 `search()` / `validMoves()` は新メソッドへ委譲（振る舞い不変）
- `isGameOver` を `board.validMovesFor(opponent)` ベースに変更し、`toRaw`+`next()` の往復を削除

## なぜ
- reactivity を意図的にバイパスする `toRaw` 直接ミューテートは将来サイレントに壊れるリスク
- 「ゲーム終了か」は Board が持つべき知識。store 側の手番操作で代替していた責務漏れを解消

## 安全性
- 純粋なリファクタで振る舞いは不変
- `validMovesFor` の契約（指定色の合法手を返す・`turn` 不変）を固定するテストを追加
- 既存の `gameOver.spec.ts`（両者パス→ゲームオーバー等）を安全網に全 160 テスト green、type-check / lint / build OK

closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)